### PR TITLE
chore: [CN-22] align go.yml workflow jobs names

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +22,7 @@ jobs:
         run: go test -v ./...
 
   coverage:
-    name: Go test coverage check
+    name: test coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Adjust the naming of go.yml workflow jobs. Keep them as lowercase short names.