### PR TITLE
feat: [CN-5] don't display pointer sumbol by default; make it to be a…

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -78,6 +78,13 @@ func UseJSONTagName(v bool) {
 	globalInstance.parser.UseJSONTagName(v)
 }
 
+// DisplayPointerSymbol sets whether to display the '&' (pointer symbol) before the pointed value.
+// It applies this change to the global instance of Processor.
+// By default, this option is disabled.
+func DisplayPointerSymbol(v bool) {
+	globalInstance.formatter.DisplayPointerSymbol(v)
+}
+
 // DisplayStructName sets whether to display the name of the struct.
 // It applies this change to the global instance of Processor.
 // By default, this option is disabled.

--- a/censor_test.go
+++ b/censor_test.go
@@ -119,6 +119,19 @@ func Test_InstanceConfiguration(t *testing.T) {
 		got := p.Format(testStruct{Name: "John", Age: 30})
 		require.Equal(t, exp, got)
 	})
+
+	t.Run("display_pointer_symbol", func(t *testing.T) {
+		p := New()
+		p.DisplayPointerSymbol(true)
+
+		type testStruct struct {
+			Names *[]string `censor:"display"`
+		}
+
+		exp := `{Names: &[John, Nazar]}`
+		got := p.Format(testStruct{Names: &[]string{"John", "Nazar"}})
+		require.Equal(t, exp, got)
+	})
 }
 
 func Test_GlobalInstanceConfiguration(t *testing.T) {
@@ -219,6 +232,20 @@ func Test_GlobalInstanceConfiguration(t *testing.T) {
 
 		exp := `censor.testStruct{age: 30}`
 		got := Format(testStruct{Name: "John", Age: 30})
+		require.Equal(t, exp, got)
+	})
+
+	t.Run("display_pointer_symbol", func(t *testing.T) {
+		t.Cleanup(func() { SetGlobalInstance(New()) })
+
+		DisplayPointerSymbol(true)
+
+		type testStruct struct {
+			Names *[]string `censor:"display"`
+		}
+
+		exp := `{Names: &[John, Nazar]}`
+		got := Format(testStruct{Names: &[]string{"John", "Nazar"}})
 		require.Equal(t, exp, got)
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,9 @@ type Formatter struct {
 	// MaskValue is used to mask struct fields with sensitive data.
 	// The default value is stored in DefaultMaskValue constant.
 	MaskValue string
+	// DisplayPointerSymbol is used to display '&' (pointer symbol) in the output.
+	// The default value is false.
+	DisplayPointerSymbol bool
 	// DisplayStructName is used to hide struct name in the output.
 	// The default value is false.
 	DisplayStructName bool
@@ -39,10 +42,11 @@ func Default() Config {
 			UseJSONTagName: false,
 		},
 		Formatter: Formatter{
-			MaskValue:         DefaultMaskValue,
-			DisplayStructName: false,
-			DisplayMapType:    false,
-			ExcludePatterns:   nil,
+			MaskValue:            DefaultMaskValue,
+			DisplayPointerSymbol: false,
+			DisplayStructName:    false,
+			DisplayMapType:       false,
+			ExcludePatterns:      nil,
 		},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,10 +13,11 @@ func TestDefault(t *testing.T) {
 			UseJSONTagName: false,
 		},
 		Formatter: Formatter{
-			MaskValue:         DefaultMaskValue,
-			DisplayStructName: false,
-			DisplayMapType:    false,
-			ExcludePatterns:   nil,
+			MaskValue:            DefaultMaskValue,
+			DisplayPointerSymbol: false,
+			DisplayStructName:    false,
+			DisplayMapType:       false,
+			ExcludePatterns:      nil,
 		},
 	}
 
@@ -35,10 +36,11 @@ func TestConfig_GetParserConfig(t *testing.T) {
 func TestConfig_GetFormatterConfig(t *testing.T) {
 	got := Default().GetFormatterConfig()
 	exp := Formatter{
-		MaskValue:         DefaultMaskValue,
-		DisplayStructName: false,
-		DisplayMapType:    false,
-		ExcludePatterns:   nil,
+		MaskValue:            DefaultMaskValue,
+		DisplayPointerSymbol: false,
+		DisplayStructName:    false,
+		DisplayMapType:       false,
+		ExcludePatterns:      nil,
 	}
 
 	require.EqualValues(t, exp, got)

--- a/internal/formatter/format.go
+++ b/internal/formatter/format.go
@@ -14,6 +14,9 @@ type Formatter struct {
 	// maskValue is used to mask struct fields with sensitive data.
 	// The default value is stored in config.DefaultMaskValue constant.
 	maskValue string
+	// displayPointerSymbol is used to display '&' (pointer symbol) in the output.
+	// The default value is false.
+	displayPointerSymbol bool
 	// displayStructName is used to hide struct name in the output.
 	// The default value is false.
 	displayStructName bool
@@ -29,19 +32,23 @@ type Formatter struct {
 // New returns a new instance of Formatter with default configuration.
 func New() *Formatter {
 	return &Formatter{
-		maskValue:         config.DefaultMaskValue,
-		displayStructName: false,
-		displayMapType:    false,
+		maskValue:               config.DefaultMaskValue,
+		displayPointerSymbol:    false,
+		displayStructName:       false,
+		displayMapType:          false,
+		excludePatterns:         nil,
+		excludePatternsCompiled: nil,
 	}
 }
 
 // NewWithConfig returns a new instance of Formatter with given configuration.
 func NewWithConfig(cfg config.Formatter) *Formatter {
 	f := Formatter{
-		maskValue:         cfg.MaskValue,
-		displayStructName: cfg.DisplayStructName,
-		displayMapType:    cfg.DisplayMapType,
-		excludePatterns:   cfg.ExcludePatterns,
+		maskValue:            cfg.MaskValue,
+		displayPointerSymbol: cfg.DisplayPointerSymbol,
+		displayStructName:    cfg.DisplayStructName,
+		displayMapType:       cfg.DisplayMapType,
+		excludePatterns:      cfg.ExcludePatterns,
 	}
 
 	if len(f.excludePatterns) != 0 {
@@ -65,6 +72,11 @@ func (f *Formatter) compileExcludePatterns() {
 // SetMaskValue sets a value that will be used to mask struct fields.
 func (f *Formatter) SetMaskValue(mask string) {
 	f.maskValue = mask
+}
+
+// DisplayPointerSymbol sets whether to display the '&' (pointer symbol) before the pointed value.
+func (f *Formatter) DisplayPointerSymbol(v bool) {
+	f.displayPointerSymbol = v
 }
 
 // DisplayStructName sets whether to display the name of the struct.

--- a/internal/formatter/format_test.go
+++ b/internal/formatter/format_test.go
@@ -15,9 +15,12 @@ import (
 
 func TestFormatter_writeValue(t *testing.T) {
 	f := Formatter{
-		maskValue:         config.DefaultMaskValue,
-		displayStructName: false,
-		displayMapType:    false,
+		maskValue:               config.DefaultMaskValue,
+		displayPointerSymbol:    false,
+		displayStructName:       false,
+		displayMapType:          false,
+		excludePatterns:         nil,
+		excludePatternsCompiled: nil,
 	}
 	var buf strings.Builder
 
@@ -344,7 +347,7 @@ func TestFormatter_writeValue(t *testing.T) {
 				Kind: reflect.Ptr,
 			}
 			f.writeValue(&buf, v)
-			exp := `&Kholodetsʹ`
+			exp := `Kholodetsʹ`
 			require.Equal(t, exp, buf.String())
 		})
 	})
@@ -835,7 +838,7 @@ func TestFormatter_writeField(t *testing.T) {
 				Kind: reflect.Ptr,
 			}
 			f.writeField(field, &buf)
-			exp := `Dish: &Kholodetsʹ`
+			exp := `Dish: Kholodetsʹ`
 			require.Equal(t, exp, buf.String())
 		})
 	})
@@ -902,6 +905,12 @@ func TestFormatter_SetMaskValue(t *testing.T) {
 	f := &Formatter{maskValue: config.DefaultMaskValue, displayStructName: false, displayMapType: false}
 	f.SetMaskValue("[censored]")
 	require.EqualValues(t, f, &Formatter{maskValue: "[censored]", displayStructName: false, displayMapType: false})
+}
+
+func TestFormatter_DisplayPointerSymbol(t *testing.T) {
+	f := &Formatter{maskValue: config.DefaultMaskValue, displayPointerSymbol: true, displayStructName: false, displayMapType: false}
+	f.DisplayPointerSymbol(true)
+	require.EqualValues(t, f, &Formatter{maskValue: config.DefaultMaskValue, displayPointerSymbol: true, displayStructName: false, displayMapType: false})
 }
 
 func TestFormatter_DisplayStructName(t *testing.T) {

--- a/internal/formatter/pointer.go
+++ b/internal/formatter/pointer.go
@@ -6,16 +6,25 @@ import (
 	"github.com/vpakhuchyi/censor/internal/models"
 )
 
+// PointerSymbol is used to display the pointer to the value in the output.
+const PointerSymbol = "&"
+
 // Ptr formats a pointer into a string.
-// It adds the `&` prefix to the formatted value to indicate that it is a pointer.
 // Pointer value is formatted according to the rules of the underlying type.
+// If the pointer is nil, the string "nil" is returned.
+// It's possible to display the pointer symbol in the output by setting the DisplayPointerSymbol field to true
+// in the Formatter configuration.
 func (f *Formatter) Ptr(ptr models.Ptr) string {
 	if ptr.Value == nil {
 		return "nil"
 	}
 
 	buf := strings.Builder{}
-	buf.WriteString("&")
+
+	if f.displayPointerSymbol {
+		buf.WriteString(PointerSymbol)
+	}
+
 	f.writeValue(&buf, models.Value(ptr))
 
 	return buf.String()

--- a/internal/formatter/pointer_test.go
+++ b/internal/formatter/pointer_test.go
@@ -12,12 +12,27 @@ import (
 
 func TestFormatter_Ptr(t *testing.T) {
 	f := Formatter{
-		maskValue:         config.DefaultMaskValue,
-		displayStructName: false,
-		displayMapType:    false,
+		maskValue:            config.DefaultMaskValue,
+		displayPointerSymbol: false,
+		displayStructName:    false,
+		displayMapType:       false,
 	}
 
 	t.Run("successful", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			v := models.Ptr{Value: 1, Kind: reflect.Int}
+			got := f.Ptr(v)
+			exp := "1"
+			require.Equal(t, exp, got)
+		})
+	})
+
+	t.Run("successful_with_pointer_symbol", func(t *testing.T) {
+		f := Formatter{
+			maskValue:            config.DefaultMaskValue,
+			displayPointerSymbol: true,
+		}
+
 		require.NotPanics(t, func() {
 			v := models.Ptr{Value: 1, Kind: reflect.Int}
 			got := f.Ptr(v)
@@ -29,6 +44,7 @@ func TestFormatter_Ptr(t *testing.T) {
 	t.Run("with_exclude_patterns", func(t *testing.T) {
 		f := Formatter{
 			maskValue:               config.DefaultMaskValue,
+			displayPointerSymbol:    false,
 			displayStructName:       false,
 			displayMapType:          false,
 			excludePatterns:         []string{`\d`, `\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`},
@@ -38,7 +54,7 @@ func TestFormatter_Ptr(t *testing.T) {
 		require.NotPanics(t, func() {
 			v := models.Ptr{Value: "hell0", Kind: reflect.String}
 			got := f.Ptr(v)
-			exp := "&[CENSORED]"
+			exp := "[CENSORED]"
 			require.Equal(t, exp, got)
 		})
 	})

--- a/processor.go
+++ b/processor.go
@@ -80,6 +80,12 @@ func (p *Processor) UseJSONTagName(v bool) {
 	p.parser.UseJSONTagName(v)
 }
 
+// DisplayPointerSymbol sets whether to display the '&' (pointer symbol) before the pointed value.
+// By default, this option is disabled.
+func (p *Processor) DisplayPointerSymbol(v bool) {
+	p.formatter.DisplayPointerSymbol(v)
+}
+
 // DisplayStructName sets whether to display the name of the struct.
 // By default, this option is disabled.
 func (p *Processor) DisplayStructName(v bool) {

--- a/processor_test.go
+++ b/processor_test.go
@@ -408,7 +408,7 @@ func TestProcessor_format(t *testing.T) {
 				},
 				Kind: reflect.Struct,
 			}
-			exp := `&{Int64: 123456789, String: string}`
+			exp := `{Int64: 123456789, String: string}`
 
 			got := p.format(reflect.Pointer, val)
 			require.Equal(t, exp, got)
@@ -696,10 +696,11 @@ func TestNewWithConfig(t *testing.T) {
 			UseJSONTagName: false,
 		},
 		Formatter: config.Formatter{
-			MaskValue:         "####",
-			DisplayStructName: false,
-			DisplayMapType:    false,
-			ExcludePatterns:   nil,
+			MaskValue:            "####",
+			DisplayPointerSymbol: false,
+			DisplayStructName:    false,
+			DisplayMapType:       false,
+			ExcludePatterns:      nil,
 		},
 	}
 	got := NewWithConfig(cfg)


### PR DESCRIPTION
Don't display '&' (pointer symbol) before the pointed value by default. 
Make this behaviour to be configurable. 