### PR TITLE
feat: [CN-2] update the docs to specify that struct name includes the last part of pkg path

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -86,6 +86,7 @@ func DisplayPointerSymbol(v bool) {
 }
 
 // DisplayStructName sets whether to display the name of the struct.
+// A struct name includes the last part of the package path.
 // It applies this change to the global instance of Processor.
 // By default, this option is disabled.
 func DisplayStructName(v bool) {

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,8 @@ type Formatter struct {
 	// DisplayPointerSymbol is used to display '&' (pointer symbol) in the output.
 	// The default value is false.
 	DisplayPointerSymbol bool
-	// DisplayStructName is used to hide struct name in the output.
+	// DisplayStructName is used to display struct name in the output.
+	// A struct name includes the last part of the package path.
 	// The default value is false.
 	DisplayStructName bool
 	// DisplayMapType is used to display map type in the output.

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,14 +168,14 @@ All configuration options can be set using the package-level functions as shown 
 a new instance of `censor.Processor` and use its methods to configure it. All of these options are available with both
 local and global instances.
 
-| Global option                                 | Description                                                          |
-|-----------------------------------------------|----------------------------------------------------------------------|
-| censor.SetMaskValue(s string)                 | Set custom mask value instead of default `[CENSORED]`.               |
-| censor.UseJSONTagName(b bool)                 | Use JSON tag name instead of struct field name.                      |
-| censor.DisplayPointerSymbol(b bool)           | Display '&' (pointer symbol) before the pointed value in the output. |
-| censor.DisplayStructName(b bool)              | Display struct name in the output.                                   |
-| censor.DisplayMapType(b bool)                 | Display map type in the output.                                      |
-| censor.AddExcludePatterns(patterns ...string) | Add regexp patterns for matched strings values masking.              |
+| Global option                                 | Description                                                                      |
+|-----------------------------------------------|----------------------------------------------------------------------------------|
+| censor.SetMaskValue(s string)                 | Set custom mask value instead of default `[CENSORED]`.                           |
+| censor.UseJSONTagName(b bool)                 | Use JSON tag name instead of struct field name.                                  |
+| censor.DisplayPointerSymbol(b bool)           | Display '&' (pointer symbol) before the pointed value in the output.             |
+| censor.DisplayStructName(b bool)              | Display struct name (including the last part of the package path) in the output. |
+| censor.DisplayMapType(b bool)                 | Display map type in the output.                                                  |
+| censor.AddExcludePatterns(patterns ...string) | Add regexp patterns for matched strings values masking.                          |
 
 Apart from this, it's possible to define a configuration using `config.Config` struct.
 

--- a/internal/formatter/format.go
+++ b/internal/formatter/format.go
@@ -17,7 +17,8 @@ type Formatter struct {
 	// displayPointerSymbol is used to display '&' (pointer symbol) in the output.
 	// The default value is false.
 	displayPointerSymbol bool
-	// displayStructName is used to hide struct name in the output.
+	// displayStructName is used to display struct name in the output.
+	// A struct name includes the last part of the package path.
 	// The default value is false.
 	displayStructName bool
 	// displayMapType is used to display map type in the output.


### PR DESCRIPTION
https://censor.atlassian.net/browse/CN-2

Update the documentation to bold that when DisplayStructName config option is enabled a struct name will include the last part of its pkg path. 