### PR TITLE
feat: [CN-1] align useJSONTagName cfg option in case of empty tag with json pkg in stdlib

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -72,7 +72,7 @@ func SetMaskValue(maskValue string) {
 
 // UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
 // It applies this change to the global instance of Processor.
-// If no `json` tag is present, the name of struct will be an empty string.
+// If no `json` tag is present, the name of the struct field is used.
 // By default, this option is disabled.
 func UseJSONTagName(v bool) {
 	globalInstance.parser.UseJSONTagName(v)

--- a/censor_test.go
+++ b/censor_test.go
@@ -64,7 +64,7 @@ func Test_InstanceConfiguration(t *testing.T) {
 			Email string
 		}
 
-		exp := `{name: John, age: [CENSORED]}`
+		exp := `{name: John, age: [CENSORED], Email: [CENSORED]}`
 		got := p.Format(testStruct{Name: "John", Age: 30})
 		require.Equal(t, exp, got)
 	})
@@ -115,7 +115,7 @@ func Test_InstanceConfiguration(t *testing.T) {
 			Age  int    `json:"age" censor:"display"`
 		}
 
-		exp := `censor.testStruct{age: 30}`
+		exp := `censor.testStruct{Name: John, age: 30}`
 		got := p.Format(testStruct{Name: "John", Age: 30})
 		require.Equal(t, exp, got)
 	})
@@ -230,7 +230,7 @@ func Test_GlobalInstanceConfiguration(t *testing.T) {
 		p := NewWithConfig(c)
 		SetGlobalInstance(p)
 
-		exp := `censor.testStruct{age: 30}`
+		exp := `censor.testStruct{Name: John, age: 30}`
 		got := Format(testStruct{Name: "John", Age: 30})
 		require.Equal(t, exp, got)
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 // Parser describes parser.Parser configuration.
 type Parser struct {
 	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-	// If no `json` tag is present, the name of struct will be an empty string.
+	// If no `json` tag is present, the name of the struct field is used.
 	UseJSONTagName bool
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,7 +10,7 @@ const DefaultCensorFieldTag = "censor"
 // Parser is a struct that contains options for parsing.
 type Parser struct {
 	// useJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-	// If no `json` tag is present, the name of struct will be an empty string.
+	// If no `json` tag is present, the name of the struct field is used.
 	useJSONTagName bool
 	// censorFieldTag is a tag name for censor fields.
 	// The default value is stored in the DefaultCensorFieldTag constant.
@@ -34,7 +34,7 @@ func NewWithConfig(p config.Parser) *Parser {
 }
 
 // UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-// If no `json` tag is present, the name of struct will be an empty string.
+// If no `json` tag is present, the name of the struct field is used.
 func (p *Parser) UseJSONTagName(v bool) {
 	p.useJSONTagName = v
 }

--- a/internal/parser/struct.go
+++ b/internal/parser/struct.go
@@ -30,21 +30,21 @@ func (p *Parser) Struct(rv reflect.Value) models.Struct {
 			continue
 		}
 
+		strField := rv.Type().Field(i)
+
 		field := models.Field{
-			Opts: options.Parse(rv.Type().Field(i).Tag.Get(p.censorFieldTag)),
-			Kind: rv.Field(i).Kind(),
+			Opts: options.Parse(strField.Tag.Get(p.censorFieldTag)),
+			Kind: f.Kind(),
 		}
 
 		if p.useJSONTagName {
-			tagValue := rv.Type().Field(i).Tag.Get("json")
-			if tagValue == "" {
-				// If the tag is not present, then such a field will be ignored.
-				continue
+			if jsonName, ok := strField.Tag.Lookup("json"); ok {
+				field.Name = jsonName
+			} else {
+				field.Name = strField.Name // If tag is absent, then a struct filed name shall be used.
 			}
-
-			field.Name = tagValue
 		} else {
-			field.Name = rv.Type().Field(i).Name
+			field.Name = strField.Name
 		}
 
 		switch k := field.Kind; k {

--- a/internal/parser/struct_test.go
+++ b/internal/parser/struct_test.go
@@ -550,6 +550,7 @@ func TestParser_StructWithJSONTags(t *testing.T) {
 					{Name: "city", Value: models.Value{Value: "San Francisco", Kind: reflect.String}, Opts: options.FieldOptions{Display: true}, Kind: reflect.String},
 					{Name: "state", Value: models.Value{Value: "CA", Kind: reflect.String}, Opts: options.FieldOptions{Display: true}, Kind: reflect.String},
 					{Name: "street", Value: models.Value{Value: "451 Main St", Kind: reflect.String}, Opts: options.FieldOptions{Display: false}, Kind: reflect.String},
+					{Name: "Zip", Value: models.Value{Value: "55501", Kind: reflect.String}, Opts: options.FieldOptions{Display: false}, Kind: reflect.String},
 				}}
 
 			require.Equal(t, exp, got)

--- a/processor.go
+++ b/processor.go
@@ -74,7 +74,7 @@ func (p *Processor) SetMaskValue(maskValue string) {
 }
 
 // UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-// If no `json` tag is present, the name of struct will be an empty string.
+// If no `json` tag is present, the name of the struct field is used.
 // By default, this option is disabled.
 func (p *Processor) UseJSONTagName(v bool) {
 	p.parser.UseJSONTagName(v)


### PR DESCRIPTION
https://censor.atlassian.net/browse/CN-1

After the investigation a decision to have the same behaviour as `json` lib in stdlib was made. 
So, in case if a `useJSONTagName` option is enabled but there is no `json` tag - a struct filed name is used.