### PR TITLE
feat: [CN-17] add a possibility to configure floats max significant figures number

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -106,3 +106,17 @@ func DisplayMapType(v bool) {
 func AddExcludePatterns(patterns ...string) {
 	globalInstance.formatter.AddExcludePatterns(patterns...)
 }
+
+// SetFloat32MaxSignificantFigures sets the maximum number of significant figures for float32.
+// It applies this change to the global instance of Processor.
+// The default value is stored in the config.Float32MaxSignificantFigures constant.
+func SetFloat32MaxSignificantFigures(v int) {
+	globalInstance.formatter.SetFloat32MaxSignificantFigures(v)
+}
+
+// SetFloat64MaxSignificantFigures sets the maximum number of significant figures for float64.
+// It applies this change to the global instance of Processor.
+// The default value is stored in the config.Float64MaxSignificantFigures constant.
+func SetFloat64MaxSignificantFigures(v int) {
+	globalInstance.formatter.SetFloat64MaxSignificantFigures(v)
+}

--- a/censor_test.go
+++ b/censor_test.go
@@ -1,6 +1,7 @@
 package censor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -132,6 +133,32 @@ func Test_InstanceConfiguration(t *testing.T) {
 		got := p.Format(testStruct{Names: &[]string{"John", "Nazar"}})
 		require.Equal(t, exp, got)
 	})
+
+	t.Run("custom_float32_max_sig_figs", func(t *testing.T) {
+		p := New()
+		p.SetFloat32MaxSignificantFigures(3)
+
+		type testStruct struct {
+			Weight float32 `censor:"display"`
+		}
+
+		exp := `{Weight: 58.9}`
+		got := p.Format(testStruct{Weight: 58.9350})
+		require.Equal(t, exp, got)
+	})
+
+	t.Run("custom_float64_max_sig_figs", func(t *testing.T) {
+		p := New()
+		p.SetFloat64MaxSignificantFigures(10)
+
+		type testStruct struct {
+			Pi float64 `censor:"display"`
+		}
+
+		exp := `{Pi: 3.141592654}`
+		got := p.Format(testStruct{Pi: math.Pi})
+		require.Equal(t, exp, got)
+	})
 }
 
 func Test_GlobalInstanceConfiguration(t *testing.T) {
@@ -246,6 +273,34 @@ func Test_GlobalInstanceConfiguration(t *testing.T) {
 
 		exp := `{Names: &[John, Nazar]}`
 		got := Format(testStruct{Names: &[]string{"John", "Nazar"}})
+		require.Equal(t, exp, got)
+	})
+
+	t.Run("custom_float32_max_sig_figs", func(t *testing.T) {
+		t.Cleanup(func() { SetGlobalInstance(New()) })
+
+		SetFloat32MaxSignificantFigures(3)
+
+		type testStruct struct {
+			Weight float32 `censor:"display"`
+		}
+
+		exp := `{Weight: 58.9}`
+		got := Format(testStruct{Weight: 58.9350})
+		require.Equal(t, exp, got)
+	})
+
+	t.Run("custom_float64_max_sig_figs", func(t *testing.T) {
+		t.Cleanup(func() { SetGlobalInstance(New()) })
+
+		SetFloat64MaxSignificantFigures(10)
+
+		type testStruct struct {
+			Pi float64 `censor:"display"`
+		}
+
+		exp := `{Pi: 3.141592654}`
+		got := Format(testStruct{Pi: math.Pi})
 		require.Equal(t, exp, got)
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,6 @@ const (
 	Float32MaxSignificantFigures = 7
 	// Float64MaxSignificantFigures is the default maximum number of significant figures for float64.
 	Float64MaxSignificantFigures = 15
-
-	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 )
 
 // Config describes the available parser.Parser and formatter.Formatter configuration.
@@ -44,11 +42,11 @@ type Formatter struct {
 	// of strings that must be masked.
 	ExcludePatterns []string
 	// Float32MaxSignificantFigures is the maximum number of significant figures for float32.
-	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 	Float32MaxSignificantFigures int
 	// Float64MaxSignificantFigures is the maximum number of significant figures for float64.
-	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 	Float64MaxSignificantFigures int
+
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 }
 
 // Default returns a default configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,15 @@ package config
 // DefaultMaskValue is used to mask struct fields by default.
 const DefaultMaskValue = "[CENSORED]"
 
+const (
+	// Float32MaxSignificantFigures is the default maximum number of significant figures for float32.
+	Float32MaxSignificantFigures = 7
+	// Float64MaxSignificantFigures is the default maximum number of significant figures for float64.
+	Float64MaxSignificantFigures = 15
+
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
+)
+
 // Config describes the available parser.Parser and formatter.Formatter configuration.
 type Config struct {
 	Parser    Parser
@@ -34,6 +43,12 @@ type Formatter struct {
 	// ExcludePatterns contains regexp patterns that are used for the selection
 	// of strings that must be masked.
 	ExcludePatterns []string
+	// Float32MaxSignificantFigures is the maximum number of significant figures for float32.
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
+	Float32MaxSignificantFigures int
+	// Float64MaxSignificantFigures is the maximum number of significant figures for float64.
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
+	Float64MaxSignificantFigures int
 }
 
 // Default returns a default configuration.
@@ -43,11 +58,13 @@ func Default() Config {
 			UseJSONTagName: false,
 		},
 		Formatter: Formatter{
-			MaskValue:            DefaultMaskValue,
-			DisplayPointerSymbol: false,
-			DisplayStructName:    false,
-			DisplayMapType:       false,
-			ExcludePatterns:      nil,
+			MaskValue:                    DefaultMaskValue,
+			DisplayPointerSymbol:         false,
+			DisplayStructName:            false,
+			DisplayMapType:               false,
+			ExcludePatterns:              nil,
+			Float32MaxSignificantFigures: Float32MaxSignificantFigures,
+			Float64MaxSignificantFigures: Float64MaxSignificantFigures,
 		},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,11 +13,13 @@ func TestDefault(t *testing.T) {
 			UseJSONTagName: false,
 		},
 		Formatter: Formatter{
-			MaskValue:            DefaultMaskValue,
-			DisplayPointerSymbol: false,
-			DisplayStructName:    false,
-			DisplayMapType:       false,
-			ExcludePatterns:      nil,
+			MaskValue:                    DefaultMaskValue,
+			DisplayPointerSymbol:         false,
+			DisplayStructName:            false,
+			DisplayMapType:               false,
+			ExcludePatterns:              nil,
+			Float32MaxSignificantFigures: Float32MaxSignificantFigures,
+			Float64MaxSignificantFigures: Float64MaxSignificantFigures,
 		},
 	}
 
@@ -36,11 +38,13 @@ func TestConfig_GetParserConfig(t *testing.T) {
 func TestConfig_GetFormatterConfig(t *testing.T) {
 	got := Default().GetFormatterConfig()
 	exp := Formatter{
-		MaskValue:            DefaultMaskValue,
-		DisplayPointerSymbol: false,
-		DisplayStructName:    false,
-		DisplayMapType:       false,
-		ExcludePatterns:      nil,
+		MaskValue:                    DefaultMaskValue,
+		DisplayPointerSymbol:         false,
+		DisplayStructName:            false,
+		DisplayMapType:               false,
+		ExcludePatterns:              nil,
+		Float32MaxSignificantFigures: Float32MaxSignificantFigures,
+		Float64MaxSignificantFigures: Float64MaxSignificantFigures,
 	}
 
 	require.EqualValues(t, exp, got)

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,8 @@ local and global instances.
 | censor.DisplayStructName(b bool)              | Display struct name (including the last part of the package path) in the output. |
 | censor.DisplayMapType(b bool)                 | Display map type in the output.                                                  |
 | censor.AddExcludePatterns(patterns ...string) | Add regexp patterns for matched strings values masking.                          |
+| censor.SetFloat32MaxSignificantFigures(v int) | Set the maximum number of significant figures for float32 type.                  |
+| censor.SetFloat64MaxSignificantFigures(v int) | Set the maximum number of significant figures for float64 type.                  |m
 
 Apart from this, it's possible to define a configuration using `config.Config` struct.
 
@@ -429,7 +431,11 @@ func main() {
 
 ### Float64/Float32
 
-Floating-point types are formatted to include up to 15 (float64) and 7 (float32) significant figures respectively.
+By default, the floating-point types are formatted to include up to 15 (float64) and 7 (float32) significant figures 
+respectively. To change the number of significant figures, you can use the `SetFloat32MaxSignificantFigures(v int)` or 
+`SetFloat64MaxSignificantFigures(v int)` functions/methods.
+
+More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 
 ```go
 package main

--- a/internal/formatter/float.go
+++ b/internal/formatter/float.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/vpakhuchyi/censor/internal/models"
 )
@@ -15,9 +16,17 @@ func (f *Formatter) Float(v models.Value) string {
 		panic("provided value is not a float")
 	}
 
+	// Significant figures are the meaningful digits in a number. They indicate
+	// the precision of a measurement. For example, in the number 123.4558, there
+	// are seven significant figures, and rounding to four significant figures
+	// would result in 123.5.
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
+	var maxSignificantFigures string
 	if v.Kind == reflect.Float32 {
-		return fmt.Sprintf(`%.7g`, v.Value)
+		maxSignificantFigures = strconv.Itoa(f.float32MaxSignificantFigures)
+	} else {
+		maxSignificantFigures = strconv.Itoa(f.float64MaxSignificantFigures)
 	}
 
-	return fmt.Sprintf(`%.15g`, v.Value)
+	return fmt.Sprintf("%."+maxSignificantFigures+"g", v.Value)
 }

--- a/internal/formatter/float_test.go
+++ b/internal/formatter/float_test.go
@@ -12,9 +12,11 @@ import (
 
 func TestFormatter_Float(t *testing.T) {
 	f := Formatter{
-		maskValue:         config.DefaultMaskValue,
-		displayStructName: false,
-		displayMapType:    false,
+		maskValue:                    config.DefaultMaskValue,
+		displayStructName:            false,
+		displayMapType:               false,
+		float32MaxSignificantFigures: config.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: config.Float64MaxSignificantFigures,
 	}
 
 	t.Run("float32", func(t *testing.T) {

--- a/internal/formatter/format.go
+++ b/internal/formatter/format.go
@@ -28,28 +28,40 @@ type Formatter struct {
 	excludePatterns []string
 	// excludePatternsCompiled contains already compiled regexp patterns from excludePatterns.
 	excludePatternsCompiled []*regexp.Regexp
+	// float32MaxSignificantFigures is the maximum number of significant figures for float32.
+	// The default value is stored in config.Float32MaxSignificantDigits constant.
+	float32MaxSignificantFigures int
+	// float64MaxSignificantFigures is the maximum number of significant figures for float64.
+	// The default value is stored in config.Float64MaxSignificantDigits constant.
+	float64MaxSignificantFigures int
+
+	// More details about significant figures: https://en.wikipedia.org/wiki/Significant_figures.
 }
 
 // New returns a new instance of Formatter with default configuration.
 func New() *Formatter {
 	return &Formatter{
-		maskValue:               config.DefaultMaskValue,
-		displayPointerSymbol:    false,
-		displayStructName:       false,
-		displayMapType:          false,
-		excludePatterns:         nil,
-		excludePatternsCompiled: nil,
+		maskValue:                    config.DefaultMaskValue,
+		displayPointerSymbol:         false,
+		displayStructName:            false,
+		displayMapType:               false,
+		excludePatterns:              nil,
+		excludePatternsCompiled:      nil,
+		float32MaxSignificantFigures: config.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: config.Float64MaxSignificantFigures,
 	}
 }
 
 // NewWithConfig returns a new instance of Formatter with given configuration.
 func NewWithConfig(cfg config.Formatter) *Formatter {
 	f := Formatter{
-		maskValue:            cfg.MaskValue,
-		displayPointerSymbol: cfg.DisplayPointerSymbol,
-		displayStructName:    cfg.DisplayStructName,
-		displayMapType:       cfg.DisplayMapType,
-		excludePatterns:      cfg.ExcludePatterns,
+		maskValue:                    cfg.MaskValue,
+		displayPointerSymbol:         cfg.DisplayPointerSymbol,
+		displayStructName:            cfg.DisplayStructName,
+		displayMapType:               cfg.DisplayMapType,
+		excludePatterns:              cfg.ExcludePatterns,
+		float32MaxSignificantFigures: cfg.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: cfg.Float64MaxSignificantFigures,
 	}
 
 	if len(f.excludePatterns) != 0 {
@@ -96,6 +108,16 @@ func (f *Formatter) DisplayMapType(v bool) {
 func (f *Formatter) AddExcludePatterns(patterns ...string) {
 	f.excludePatterns = append(f.excludePatterns, patterns...)
 	f.compileExcludePatterns()
+}
+
+// SetFloat32MaxSignificantFigures sets the maximum number of significant figures for float32.
+func (f *Formatter) SetFloat32MaxSignificantFigures(v int) {
+	f.float32MaxSignificantFigures = v
+}
+
+// SetFloat64MaxSignificantFigures sets the maximum number of significant figures for float64.
+func (f *Formatter) SetFloat64MaxSignificantFigures(v int) {
+	f.float64MaxSignificantFigures = v
 }
 
 //nolint:exhaustive,gocyclo

--- a/internal/formatter/format_test.go
+++ b/internal/formatter/format_test.go
@@ -15,12 +15,14 @@ import (
 
 func TestFormatter_writeValue(t *testing.T) {
 	f := Formatter{
-		maskValue:               config.DefaultMaskValue,
-		displayPointerSymbol:    false,
-		displayStructName:       false,
-		displayMapType:          false,
-		excludePatterns:         nil,
-		excludePatternsCompiled: nil,
+		maskValue:                    config.DefaultMaskValue,
+		displayPointerSymbol:         false,
+		displayStructName:            false,
+		displayMapType:               false,
+		excludePatterns:              nil,
+		excludePatternsCompiled:      nil,
+		float32MaxSignificantFigures: config.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: config.Float64MaxSignificantFigures,
 	}
 	var buf strings.Builder
 
@@ -355,9 +357,11 @@ func TestFormatter_writeValue(t *testing.T) {
 
 func TestFormatter_writeField(t *testing.T) {
 	f := Formatter{
-		maskValue:         config.DefaultMaskValue,
-		displayStructName: false,
-		displayMapType:    false,
+		maskValue:                    config.DefaultMaskValue,
+		displayStructName:            false,
+		displayMapType:               false,
+		float32MaxSignificantFigures: config.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: config.Float64MaxSignificantFigures,
 	}
 	var buf strings.Builder
 
@@ -845,23 +849,37 @@ func TestFormatter_writeField(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	require.EqualValues(t, &Formatter{maskValue: config.DefaultMaskValue, displayStructName: false, displayMapType: false}, New())
+	exp := &Formatter{
+		maskValue:                    config.DefaultMaskValue,
+		displayPointerSymbol:         false,
+		displayStructName:            false,
+		displayMapType:               false,
+		excludePatterns:              nil,
+		excludePatternsCompiled:      nil,
+		float32MaxSignificantFigures: config.Float32MaxSignificantFigures,
+		float64MaxSignificantFigures: config.Float64MaxSignificantFigures,
+	}
+	require.EqualValues(t, exp, New())
 }
 
 func TestNewWithConfig(t *testing.T) {
 	t.Run("with_exclude_patterns", func(t *testing.T) {
 		got := NewWithConfig(config.Formatter{
-			MaskValue:         "[censored]",
-			DisplayStructName: true,
-			DisplayMapType:    true,
-			ExcludePatterns:   []string{`\d`},
+			MaskValue:                    "[censored]",
+			DisplayStructName:            true,
+			DisplayMapType:               true,
+			ExcludePatterns:              []string{`\d`},
+			Float32MaxSignificantFigures: 5,
+			Float64MaxSignificantFigures: 10,
 		})
 		exp := &Formatter{
-			maskValue:               "[censored]",
-			displayStructName:       true,
-			displayMapType:          true,
-			excludePatterns:         []string{`\d`},
-			excludePatternsCompiled: []*regexp.Regexp{regexp.MustCompile(`\d`)},
+			maskValue:                    "[censored]",
+			displayStructName:            true,
+			displayMapType:               true,
+			excludePatterns:              []string{`\d`},
+			excludePatternsCompiled:      []*regexp.Regexp{regexp.MustCompile(`\d`)},
+			float32MaxSignificantFigures: 5,
+			float64MaxSignificantFigures: 10,
 		}
 		require.EqualValues(t, exp, got)
 	})
@@ -957,4 +975,16 @@ func TestFormatter_ExcludePatterns(t *testing.T) {
 			require.Equal(t, expPatterns, f.excludePatterns)
 		})
 	})
+}
+
+func TestFormatter_SetFloat32MaxSignificantFigures(t *testing.T) {
+	f := &Formatter{}
+	f.SetFloat32MaxSignificantFigures(3)
+	require.EqualValues(t, f, &Formatter{float32MaxSignificantFigures: 3})
+}
+
+func TestFormatter_SetFloat64MaxSignificantFigures(t *testing.T) {
+	f := &Formatter{}
+	f.SetFloat64MaxSignificantFigures(10)
+	require.EqualValues(t, f, &Formatter{float64MaxSignificantFigures: 10})
 }

--- a/processor.go
+++ b/processor.go
@@ -105,6 +105,18 @@ func (p *Processor) AddExcludePatterns(patterns ...string) {
 	p.formatter.AddExcludePatterns(patterns...)
 }
 
+// SetFloat32MaxSignificantFigures sets the maximum number of significant figures for float32.
+// The default value is stored in the config.Float32MaxSignificantFigures constant.
+func (p *Processor) SetFloat32MaxSignificantFigures(v int) {
+	p.formatter.SetFloat32MaxSignificantFigures(v)
+}
+
+// SetFloat64MaxSignificantFigures sets the maximum number of significant figures for float64.
+// The default value is stored in the config.Float64MaxSignificantFigures constant.
+func (p *Processor) SetFloat64MaxSignificantFigures(v int) {
+	p.formatter.SetFloat64MaxSignificantFigures(v)
+}
+
 //nolint:exhaustive
 func (p *Processor) parse(v reflect.Value) any {
 	switch k := v.Kind(); k {

--- a/processor_test.go
+++ b/processor_test.go
@@ -696,11 +696,13 @@ func TestNewWithConfig(t *testing.T) {
 			UseJSONTagName: false,
 		},
 		Formatter: config.Formatter{
-			MaskValue:            "####",
-			DisplayPointerSymbol: false,
-			DisplayStructName:    false,
-			DisplayMapType:       false,
-			ExcludePatterns:      nil,
+			MaskValue:                    "####",
+			DisplayPointerSymbol:         false,
+			DisplayStructName:            false,
+			DisplayMapType:               false,
+			ExcludePatterns:              nil,
+			Float32MaxSignificantFigures: 0,
+			Float64MaxSignificantFigures: 0,
 		},
 	}
 	got := NewWithConfig(cfg)


### PR DESCRIPTION
https://censor.atlassian.net/browse/CN-17

Add `SetFloat32MaxSignificantFigures(v int)` and `SetFloat64MaxSignificantFigures(v int)` as global functions and as instance methods as well. They can be used to specify the max number of significant figures that shall be used for float values formatting. 

By default, config.Float32MaxSignificantDigits (7)  and config.Float64MaxSignificantDigits (15) constants values are used.
