### PR TITLE
feat: [CN-16] - Add support of custom structs with encoding.TextMarshaler interface

### DIFF
--- a/censor_test.go
+++ b/censor_test.go
@@ -2,6 +2,7 @@ package censor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -61,6 +62,17 @@ func Test_InstanceConfiguration(t *testing.T) {
 
 		exp := `censor.testStruct{Name: John, age: 30}`
 		got := p.Format(testStruct{Name: "John", Age: 30})
+		require.Equal(t, exp, got)
+	})
+
+	t.Run("time_text_marshaler", func(t *testing.T) {
+		p := New()
+
+		tm, err := time.Parse(time.DateOnly, "2021-01-02")
+		require.NoError(t, err)
+
+		exp := `2021-01-02T00:00:00Z`
+		got := p.Format(tm)
 		require.Equal(t, exp, got)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/vpakhuchyi/censor
 
 go 1.21
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/shopspring/decimal v1.3.1
+	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/shopspring/decimal v1.3.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/parser/interface_test.go
+++ b/internal/parser/interface_test.go
@@ -12,16 +12,16 @@ import (
 )
 
 func TestParser_Interface(t *testing.T) {
+	type person struct {
+		Names interface{} `json:"names" censor:"display"`
+	}
+
 	p := Parser{
 		useJSONTagName: false,
 		censorFieldTag: DefaultCensorFieldTag,
 	}
 
 	t.Run("struct_with_interface_with_slice_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: []string{"John", "Doe"}}
 			got := p.Struct(reflect.ValueOf(v))
@@ -97,10 +97,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_map_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: map[string]string{"first": "John", "last": "Doe"}}
 			got := p.Struct(reflect.ValueOf(v))
@@ -141,10 +137,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_pointer_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			f := 43.4
 			v := person{Names: &f}
@@ -172,10 +164,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_complex_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: complex(1.82, 0)}
 			got := p.Struct(reflect.ValueOf(v))
@@ -199,10 +187,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_bool_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: true}
 			got := p.Struct(reflect.ValueOf(v))
@@ -226,10 +210,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_int_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: 13}
 			got := p.Struct(reflect.ValueOf(v))
@@ -253,10 +233,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_float_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: 13.5}
 			got := p.Struct(reflect.ValueOf(v))
@@ -280,10 +256,6 @@ func TestParser_Interface(t *testing.T) {
 	})
 
 	t.Run("struct_with_interface_with_string_value", func(t *testing.T) {
-		type person struct {
-			Names interface{} `json:"names" censor:"display"`
-		}
-
 		require.NotPanics(t, func() {
 			v := person{Names: "John"}
 			got := p.Struct(reflect.ValueOf(v))

--- a/processor.go
+++ b/processor.go
@@ -1,6 +1,7 @@
 package censor
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 
@@ -68,9 +69,15 @@ func GetGlobalInstance() *Processor {
 // Format takes any value and returns a string representation of it masking struct fields by default.
 // To override this behaviour, use the `censor:"display"` tag.
 // Formatting is done recursively for all nested structs/slices/arrays/pointers/maps/interfaces.
+// If a value implements [encoding.TextMarshaler], the result of MarshalText is written.
 func (p *Processor) Format(val any) string {
 	if val == nil || reflect.TypeOf(val) == nil {
 		return "nil"
+	}
+
+	// If a value implements [encoding.TextMarshaler] interface, then it should be marshaled to string.
+	if tm, ok := val.(encoding.TextMarshaler); ok {
+		val = parser.PrepareTextMarshalerValue(tm)
 	}
 
 	v := reflect.ValueOf(val)


### PR DESCRIPTION
Add support of custom structs with [encoding.TextMarshaler] interface. If the structure implements the encoding.TextMarshaler interface, it will be censored as a string (encoding.TextMarshaler result).