### PR TITLE
feat: [CN-11] add a configurable option to print the configuration on any constructor call

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,17 @@ const DefaultMaskValue = "[CENSORED]"
 
 // Config describes the available parser.Parser and formatter.Formatter configuration.
 type Config struct {
+	General   General   `yaml:"general"`
 	Parser    Parser    `yaml:"parser"`
 	Formatter Formatter `yaml:"formatter"`
+}
+
+// General describes general configuration settings.
+type General struct {
+	// PrintConfigOnInit sets whether to print the configuration on initialization stage.
+	// If true, on censor.Processor initialization, the configuration will be printed to stdout.
+	// The default value is true.
+	PrintConfigOnInit bool `yaml:"print-config-on-init"`
 }
 
 // Parser describes parser.Parser configuration.
@@ -56,17 +65,10 @@ func Default() Config {
 			DisplayMapType:       false,
 			ExcludePatterns:      nil,
 		},
+		General: General{
+			PrintConfigOnInit: true,
+		},
 	}
-}
-
-// GetParserConfig returns Parser configuration from Config.
-func (c Config) GetParserConfig() Parser {
-	return c.Parser
-}
-
-// GetFormatterConfig returns Formatter configuration from Config.
-func (c Config) GetFormatterConfig() Formatter {
-	return c.Formatter
 }
 
 // FromFile reads a configuration from the given .yml file.

--- a/config/testdata/cfg.yml
+++ b/config/testdata/cfg.yml
@@ -1,8 +1,12 @@
+general:
+    print-config-on-init: true
 parser:
-  use-json-tag-name: true
+    use-json-tag-name: true
 formatter:
-  mask-value: '[CENSORED]'
-  display-pointer-symbol: true
-  display-struct-name: true
-  display-map-type: true
-  exclude-patterns: [ '\d' ]
+    mask-value: '[CENSORED]'
+    display-pointer-symbol: true
+    display-struct-name: true
+    display-map-type: true
+    exclude-patterns:
+        - \d
+        - ^\w$

--- a/config/testdata/default.yml
+++ b/config/testdata/default.yml
@@ -1,0 +1,10 @@
+general:
+    print-config-on-init: true
+parser:
+    use-json-tag-name: false
+formatter:
+    mask-value: '[CENSORED]'
+    display-pointer-symbol: false
+    display-struct-name: false
+    display-map-type: false
+    exclude-patterns: []

--- a/config/testdata/invalid_cfg.yml
+++ b/config/testdata/invalid_cfg.yml
@@ -1,8 +1,10 @@
+general:
+    print-config-on-init: true
 parser:
-  @use-json-tag-name: true
+    @use-json-tag-name: true
 formatter:
-  mask-value: '[CENSORED]'
-  display-pointer-symbol: true
-  display-struct-name: true
-  display-map-type: true
-  exclude-patterns: [ '\d' ]
+    mask-value: '[CENSORED]'
+    display-pointer-symbol: true
+    display-struct-name: true
+    display-map-type: true
+    exclude-patterns: ['\d']

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,8 +103,8 @@ import (
 )
 
 type request struct {
-  UserID   string `censor:"display"`
-  Email    string `censor:"display"`
+  UserID string `censor:"display"`
+  Email  string `censor:"display"`
 }
 
 func main() {
@@ -121,12 +121,12 @@ func main() {
 
   // Create a new instance of censor.Processor with the specified configuration and set it as a global processor.
   censor.SetGlobalProcessor(censor.NewWithConfig(cfg))
-  
+
   v := request{
-    UserID:   "001",
-    Email:    "viktor.example.email@ggmail.com",
+    UserID: "001",
+    Email:  "viktor.example.email@ggmail.com",
   }
-  
+
   slog.Info("Request", "payload", censor.Format(v))
   // Here is what we'll see in the log:
   // Output: `2038/10/25 12:00:01 INFO Request payload={UserID: 001, Email: [CENSORED]}`
@@ -173,15 +173,15 @@ All the configuration options are available in both ways.
 
 Table below shows the names of the configuration options:
 
-| Go name              | YML name               | Default value  | Description                                                                                                                                        |
-|----------------------|------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| UseJSONTagName       | use-json-tag-name      | false          | If true, the JSON tag name will be used instead of the Go struct field name.                                                                       |
-| MaskValue            | mask-value             | [CENSORED]     | The value that will be used to mask the sensitive information.                                                                                     |
-| DisplayStructName    | display-struct-name    | false          | If true, the struct name will be displayed in the output.                                                                                          |
-| DisplayMapType       | display-map-type       | false          | If true, the map type will be displayed in the output.                                                                                             |
-| DisplayPointerSymbol | display-pointer-symbol | false          | If true, '&' (the pointer symbol) will be displayed in the output.                                                                                 |
-| ExcludePatterns      | exclude-patterns       | []             | A list of regular expressions that will be compared against all the string values. <br/>If a value matches any of the patterns, it will be masked. |
-
+| Go name              | YML name               | Default value | Description                                                                                                                                        |
+|----------------------|------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| PrintConfigOnInit    | print-config-on-init   | true          | If true, the configuration will be printed when any of available constructors is used.                                                             |
+| UseJSONTagName       | use-json-tag-name      | false         | If true, the JSON tag name will be used instead of the Go struct field name.                                                                       |
+| MaskValue            | mask-value             | [CENSORED]    | The value that will be used to mask the sensitive information.                                                                                     |
+| DisplayStructName    | display-struct-name    | false         | If true, the struct name will be displayed in the output.                                                                                          |
+| DisplayMapType       | display-map-type       | false         | If true, the map type will be displayed in the output.                                                                                             |
+| DisplayPointerSymbol | display-pointer-symbol | false         | If true, '&' (the pointer symbol) will be displayed in the output.                                                                                 |
+| ExcludePatterns      | exclude-patterns       | []            | A list of regular expressions that will be compared against all the string values. <br/>If a value matches any of the patterns, it will be masked. |
 
 ### Using the `config.Config` struct
 
@@ -215,7 +215,7 @@ func main() {
 
 ### Providing `.yml` configuration file
 
-It's also possible to provide a configuration file in `.yml` format. In this case, you can use the `./cfg_example.yml` 
+It's also possible to provide a configuration file in `.yml` format. In this case, you can use the `./cfg_example.yml`
 file as an example:
 
 ```go
@@ -227,7 +227,7 @@ import (
 
 func main() {
   pathToConfigFile := "./cfg_example.yml"
-  
+
   // Create a new instance of censor.Processor with the configuration file usage.
   p, err := censor.NewWithFileConfig(pathToConfigFile)
   if err != nil {
@@ -325,7 +325,7 @@ func main() {
 
 ```
 
-There is also an option to display the map type in the output. To do this, you need to enable the `DisplayMapType` 
+There is also an option to display the map type in the output. To do this, you need to enable the `DisplayMapType`
 option in the configuration struct or file. In such a case, the output will look like this:
 
 ```go
@@ -409,7 +409,7 @@ func main() {
 
   cfg := config.Config{
     Formatter: config.Formatter{
-      MaskValue:            config.DefaultMaskValue,
+      MaskValue: config.DefaultMaskValue,
       // If you want to display the pointer symbol before the pointed value in the output,
       // you can use the `DisplayPointerSymbol` configuration option. 
       // In this case, the output will look like this:
@@ -470,8 +470,8 @@ func main() {
 
 ### Float64/Float32
 
-Due to the way Go runtime works, `float64` and `float32` types values are not always kept as the original values. 
-For example, the value `99.123456789123456789` will be stored as `99.12345678912345` for `float64` type and as 
+Due to the way Go runtime works, `float64` and `float32` types values are not always kept as the original values.
+For example, the value `99.123456789123456789` will be stored as `99.12345678912345` for `float64` type and as
 `99.12346` for `float32` type. That's before any formatting is applied.
 
 Talking about formatting, there are a few strategies that we could use to display float values.

--- a/internal/formatter/format.go
+++ b/internal/formatter/format.go
@@ -30,20 +30,8 @@ type Formatter struct {
 	excludePatternsCompiled []*regexp.Regexp
 }
 
-// New returns a new instance of Formatter with default configuration.
-func New() *Formatter {
-	return &Formatter{
-		maskValue:               config.DefaultMaskValue,
-		displayPointerSymbol:    false,
-		displayStructName:       false,
-		displayMapType:          false,
-		excludePatterns:         nil,
-		excludePatternsCompiled: nil,
-	}
-}
-
-// NewWithConfig returns a new instance of Formatter with given configuration.
-func NewWithConfig(cfg config.Formatter) *Formatter {
+// New returns a new instance of Formatter with given configuration.
+func New(cfg config.Formatter) *Formatter {
 	f := Formatter{
 		maskValue:            cfg.MaskValue,
 		displayPointerSymbol: cfg.DisplayPointerSymbol,

--- a/internal/formatter/format_test.go
+++ b/internal/formatter/format_test.go
@@ -845,12 +845,8 @@ func TestFormatter_writeField(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	require.EqualValues(t, &Formatter{maskValue: config.DefaultMaskValue, displayStructName: false, displayMapType: false}, New())
-}
-
-func TestNewWithConfig(t *testing.T) {
 	t.Run("with_exclude_patterns", func(t *testing.T) {
-		got := NewWithConfig(config.Formatter{
+		got := New(config.Formatter{
 			MaskValue:         "[censored]",
 			DisplayStructName: true,
 			DisplayMapType:    true,
@@ -867,7 +863,7 @@ func TestNewWithConfig(t *testing.T) {
 	})
 
 	t.Run("without_exclude_patterns", func(t *testing.T) {
-		got := NewWithConfig(config.Formatter{
+		got := New(config.Formatter{
 			MaskValue:         "[censored]",
 			DisplayStructName: true,
 			DisplayMapType:    true,
@@ -884,7 +880,7 @@ func TestNewWithConfig(t *testing.T) {
 	})
 
 	t.Run("with_empty_exclude_patterns", func(t *testing.T) {
-		got := NewWithConfig(config.Formatter{
+		got := New(config.Formatter{
 			MaskValue:         "[censored]",
 			DisplayStructName: true,
 			DisplayMapType:    true,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -17,16 +17,8 @@ type Parser struct {
 	censorFieldTag string
 }
 
-// New returns a new instance of Parser with default configuration.
-func New() *Parser {
-	return &Parser{
-		useJSONTagName: false,
-		censorFieldTag: DefaultCensorFieldTag,
-	}
-}
-
-// NewWithConfig returns a new instance of Parser with given configuration.
-func NewWithConfig(p config.Parser) *Parser {
+// New returns a new instance of Parser with given configuration.
+func New(p config.Parser) *Parser {
 	return &Parser{
 		useJSONTagName: p.UseJSONTagName,
 		censorFieldTag: DefaultCensorFieldTag,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -8,12 +8,8 @@ import (
 	"github.com/vpakhuchyi/censor/config"
 )
 
-func TestNew(t *testing.T) {
-	require.EqualValues(t, &Parser{useJSONTagName: false, censorFieldTag: DefaultCensorFieldTag}, New())
-}
-
-func TestNewWithConfig(t *testing.T) {
-	got := NewWithConfig(config.Parser{UseJSONTagName: true})
+func Test(t *testing.T) {
+	got := New(config.Parser{UseJSONTagName: true})
 	exp := &Parser{useJSONTagName: true, censorFieldTag: DefaultCensorFieldTag}
 	require.EqualValues(t, exp, got)
 }

--- a/processor.go
+++ b/processor.go
@@ -3,6 +3,9 @@ package censor
 import (
 	"fmt"
 	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/vpakhuchyi/censor/config"
 	"github.com/vpakhuchyi/censor/internal/formatter"
@@ -14,6 +17,7 @@ import (
 type Processor struct {
 	formatter *formatter.Formatter
 	parser    *parser.Parser
+	cfg       config.Config
 }
 
 // Censor pkg contains a global instance of Processor.
@@ -22,18 +26,29 @@ var globalInstance = New()
 
 // New returns a new instance of Processor with default configuration.
 func New() *Processor {
-	return &Processor{
-		formatter: formatter.New(),
-		parser:    parser.New(),
+	c := config.Default()
+	p := Processor{
+		formatter: formatter.New(c.Formatter),
+		parser:    parser.New(c.Parser),
+		cfg:       c,
 	}
+
+	p.PrintConfig()
+
+	return &p
 }
 
 // NewWithConfig returns a new instance of Processor with given configuration.
 func NewWithConfig(c config.Config) *Processor {
-	return &Processor{
-		formatter: formatter.NewWithConfig(c.Formatter),
-		parser:    parser.NewWithConfig(c.Parser),
+	p := Processor{
+		formatter: formatter.New(c.Formatter),
+		parser:    parser.New(c.Parser),
+		cfg:       c,
 	}
+
+	p.PrintConfig()
+
+	return &p
 }
 
 // NewWithFileConfig returns a new instance of Processor with configuration from a given file.
@@ -76,6 +91,41 @@ func (p *Processor) Format(val any) string {
 	v := reflect.ValueOf(val)
 
 	return p.format(v.Kind(), p.parse(v))
+}
+
+// PrintConfig prints the configuration of the censor Processor.
+func (p *Processor) PrintConfig() {
+	const (
+		lineLength = 69
+		padLength  = 10
+	)
+
+	line := strings.Repeat("-", lineLength) + "\n"
+
+	var b strings.Builder
+	b.WriteString(line)
+	b.WriteString(strings.Repeat(" ", padLength) + "Censor is configured with the following settings:" + "\n")
+	b.WriteString(line)
+
+	cfg := config.Config{
+		General:   p.cfg.General,
+		Parser:    p.cfg.Parser,
+		Formatter: p.cfg.Formatter,
+	}
+
+	// config.Config and its nested fields contain only supported YAML types, so it must be marshalled successfully.
+	// However, if the configuration is changed, it may contain unsupported types. To handle this case,
+	// we have tests that check whether the configuration can be marshalled.
+	// Because such kind of changes can happen only in the development process and considering that such an issue
+	// can't be fixed automatically or by the user, we don't want to fail the application in this case.
+	//
+	//nolint:errcheck
+	d, _ := yaml.Marshal(cfg)
+
+	b.Write(d)
+
+	b.WriteString(line)
+	fmt.Print(b.String())
 }
 
 //nolint:exhaustive

--- a/testdata/valid_config_console_output.txt
+++ b/testdata/valid_config_console_output.txt
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------
+          Censor is configured with the following settings:
+---------------------------------------------------------------------
+general:
+    print-config-on-init: true
+parser:
+    use-json-tag-name: false
+formatter:
+    mask-value: '[CENSORED]'
+    display-pointer-symbol: true
+    display-struct-name: true
+    display-map-type: true
+    exclude-patterns:
+        - \d
+        - .+@.+
+---------------------------------------------------------------------


### PR DESCRIPTION
https://censor.atlassian.net/browse/CN-11

1. Add a new config option to print the configuration
2. Based on that config option, if it's set to `true` - print Censor configuration to stdout
3. Remove deprecated parser/formatter constructors without the config. Now there is the only way to create them - passing the config
4. Add/adjust tests
5. Update the documentation