### PR TITLE
feat: [CN-41] reuse and embed formatter/parser config in censor.Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,9 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/vpakhuchyi/censor/internal/formatter"
+	"github.com/vpakhuchyi/censor/internal/parser"
 )
 
 // DefaultMaskValue is used to mask struct fields by default.
@@ -12,9 +15,9 @@ const DefaultMaskValue = "[CENSORED]"
 
 // Config describes the available parser.Parser and formatter.Formatter configuration.
 type Config struct {
-	General   General         `yaml:"general"`
-	Parser    ParserConfig    `yaml:"parser"`
-	Formatter FormatterConfig `yaml:"formatter"`
+	General   General          `yaml:"general"`
+	Parser    parser.Config    `yaml:"parser"`
+	Formatter formatter.Config `yaml:"formatter"`
 }
 
 // General describes general configuration settings.
@@ -25,40 +28,13 @@ type General struct {
 	PrintConfigOnInit bool `yaml:"print-config-on-init"`
 }
 
-// ParserConfig describes parser.Parser configuration.
-type ParserConfig struct {
-	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-	// If no `json` tag is present, the name of the struct field is used.
-	UseJSONTagName bool `yaml:"use-json-tag-name"`
-}
-
-// FormatterConfig describes formatter.Formatter configuration.
-type FormatterConfig struct {
-	// MaskValue is used to mask struct fields with sensitive data.
-	// The default value is stored in DefaultMaskValue constant.
-	MaskValue string `yaml:"mask-value"`
-	// DisplayPointerSymbol is used to display '&' (pointer symbol) in the output.
-	// The default value is false.
-	DisplayPointerSymbol bool `yaml:"display-pointer-symbol"`
-	// DisplayStructName is used to display struct name in the output.
-	// A struct name includes the last part of the package path.
-	// The default value is false.
-	DisplayStructName bool `yaml:"display-struct-name"`
-	// DisplayMapType is used to display map type in the output.
-	// The default value is false.
-	DisplayMapType bool `yaml:"display-map-type"`
-	// ExcludePatterns contains regexp patterns that are used for the selection
-	// of strings that must be masked.
-	ExcludePatterns []string `yaml:"exclude-patterns"`
-}
-
 // Default returns a default configuration.
 func Default() Config {
 	return Config{
-		Parser: ParserConfig{
+		Parser: parser.Config{
 			UseJSONTagName: false,
 		},
-		Formatter: FormatterConfig{
+		Formatter: formatter.Config{
 			MaskValue:            DefaultMaskValue,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/vpakhuchyi/censor/internal/formatter"
+	"github.com/vpakhuchyi/censor/internal/parser"
 )
 
 func TestDefault(t *testing.T) {
@@ -14,10 +17,10 @@ func TestDefault(t *testing.T) {
 		General: General{
 			PrintConfigOnInit: true,
 		},
-		Parser: ParserConfig{
+		Parser: parser.Config{
 			UseJSONTagName: false,
 		},
-		Formatter: FormatterConfig{
+		Formatter: formatter.Config{
 			MaskValue:            DefaultMaskValue,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
@@ -46,10 +49,10 @@ func TestFromFile(t *testing.T) {
 				General: General{
 					PrintConfigOnInit: true,
 				},
-				Parser: ParserConfig{
+				Parser: parser.Config{
 					UseJSONTagName: true,
 				},
-				Formatter: FormatterConfig{
+				Formatter: formatter.Config{
 					MaskValue:            "[CENSORED]",
 					DisplayPointerSymbol: true,
 					DisplayStructName:    true,
@@ -121,10 +124,10 @@ func TestYAMLMarshal(t *testing.T) {
 			General: General{
 				PrintConfigOnInit: true,
 			},
-			Parser: ParserConfig{
+			Parser: parser.Config{
 				UseJSONTagName: true,
 			},
-			Formatter: FormatterConfig{
+			Formatter: formatter.Config{
 				MaskValue:            "[CENSORED]",
 				DisplayPointerSymbol: true,
 				DisplayStructName:    true,

--- a/format_test.go
+++ b/format_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/vpakhuchyi/censor/internal/formatter"
+	"github.com/vpakhuchyi/censor/internal/parser"
 )
 
 func Test_InstanceFormatPrimitives(t *testing.T) {
@@ -41,13 +44,13 @@ func Test_InstanceConfiguration(t *testing.T) {
 
 	t.Run("with_provided_configuration", func(t *testing.T) {
 		c := Config{
-			Formatter: FormatterConfig{
+			Formatter: formatter.Config{
 				MaskValue:         "[redacted]",
 				DisplayStructName: true,
 				DisplayMapType:    false,
 				ExcludePatterns:   nil,
 			},
-			Parser: ParserConfig{
+			Parser: parser.Config{
 				UseJSONTagName: true,
 			},
 		}
@@ -93,13 +96,13 @@ func Test_GlobalInstanceConfiguration(t *testing.T) {
 		t.Cleanup(func() { SetGlobalInstance(New()) })
 
 		c := Config{
-			Formatter: FormatterConfig{
+			Formatter: formatter.Config{
 				MaskValue:         "[redacted]",
 				DisplayStructName: true,
 				DisplayMapType:    false,
 				ExcludePatterns:   nil,
 			},
-			Parser: ParserConfig{
+			Parser: parser.Config{
 				UseJSONTagName: true,
 			},
 		}
@@ -126,7 +129,7 @@ func Test_SetGlobalInstance(t *testing.T) {
 	t.Cleanup(func() { SetGlobalInstance(New()) })
 
 	p := NewWithConfig(Config{
-		Formatter: FormatterConfig{
+		Formatter: formatter.Config{
 			MaskValue: "[censored]",
 		},
 	})
@@ -146,7 +149,7 @@ func TestExcludePatterns(t *testing.T) {
 	t.Cleanup(func() { SetGlobalInstance(New()) })
 
 	p := NewWithConfig(Config{
-		Formatter: FormatterConfig{
+		Formatter: formatter.Config{
 			MaskValue:       "[CENSORED]",
 			ExcludePatterns: []string{`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`},
 		},

--- a/processor.go
+++ b/processor.go
@@ -28,21 +28,9 @@ var globalInstance = New()
 func New() *Processor {
 	c := Default()
 
-	fConfig := formatter.Config{
-		MaskValue:            c.Formatter.MaskValue,
-		DisplayPointerSymbol: c.Formatter.DisplayPointerSymbol,
-		DisplayStructName:    c.Formatter.DisplayStructName,
-		DisplayMapType:       c.Formatter.DisplayMapType,
-		ExcludePatterns:      c.Formatter.ExcludePatterns,
-	}
-
-	pConfig := parser.Config{
-		UseJSONTagName: c.Parser.UseJSONTagName,
-	}
-
 	p := Processor{
-		formatter: formatter.New(fConfig),
-		parser:    parser.New(pConfig),
+		formatter: formatter.New(c.Formatter),
+		parser:    parser.New(c.Parser),
 		cfg:       c,
 	}
 
@@ -53,21 +41,9 @@ func New() *Processor {
 
 // NewWithConfig returns a new instance of Processor with given configuration.
 func NewWithConfig(c Config) *Processor {
-	fConfig := formatter.Config{
-		MaskValue:            c.Formatter.MaskValue,
-		DisplayPointerSymbol: c.Formatter.DisplayPointerSymbol,
-		DisplayStructName:    c.Formatter.DisplayStructName,
-		DisplayMapType:       c.Formatter.DisplayMapType,
-		ExcludePatterns:      c.Formatter.ExcludePatterns,
-	}
-
-	pConfig := parser.Config{
-		UseJSONTagName: c.Parser.UseJSONTagName,
-	}
-
 	p := Processor{
-		formatter: formatter.New(fConfig),
-		parser:    parser.New(pConfig),
+		formatter: formatter.New(c.Formatter),
+		parser:    parser.New(c.Parser),
 		cfg:       c,
 	}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -687,10 +687,10 @@ func TestNewWithConfig(t *testing.T) {
 		General: General{
 			PrintConfigOnInit: true,
 		},
-		Parser: ParserConfig{
+		Parser: parser.Config{
 			UseJSONTagName: false,
 		},
-		Formatter: FormatterConfig{
+		Formatter: formatter.Config{
 			MaskValue:            "####",
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
@@ -808,10 +808,10 @@ func TestProcessor_PrintConfig(t *testing.T) {
 			General: General{
 				PrintConfigOnInit: true,
 			},
-			Parser: ParserConfig{
+			Parser: parser.Config{
 				UseJSONTagName: false,
 			},
-			Formatter: FormatterConfig{
+			Formatter: formatter.Config{
 				MaskValue:            DefaultMaskValue,
 				DisplayPointerSymbol: true,
 				DisplayStructName:    true,


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-41

### Description of changes
Embed parser.Config and formatter.Config to censor.Config.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
