### PR TITLE
fix: [NA] use parser and formatter config aliases in censor pkg instead of original config structs

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,9 +15,9 @@ const DefaultMaskValue = "[CENSORED]"
 
 // Config describes the available parser.Parser and formatter.Formatter configuration.
 type Config struct {
-	General   General          `yaml:"general"`
-	Parser    parser.Config    `yaml:"parser"`
-	Formatter formatter.Config `yaml:"formatter"`
+	General   General         `yaml:"general"`
+	Parser    ParserConfig    `yaml:"parser"`
+	Formatter FormatterConfig `yaml:"formatter"`
 }
 
 // General describes general configuration settings.

--- a/config_test.go
+++ b/config_test.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-
-	"github.com/vpakhuchyi/censor/internal/formatter"
-	"github.com/vpakhuchyi/censor/internal/parser"
 )
 
 func TestDefault(t *testing.T) {
@@ -17,10 +14,10 @@ func TestDefault(t *testing.T) {
 		General: General{
 			PrintConfigOnInit: true,
 		},
-		Parser: parser.Config{
+		Parser: ParserConfig{
 			UseJSONTagName: false,
 		},
-		Formatter: formatter.Config{
+		Formatter: FormatterConfig{
 			MaskValue:            DefaultMaskValue,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
@@ -49,10 +46,10 @@ func TestFromFile(t *testing.T) {
 				General: General{
 					PrintConfigOnInit: true,
 				},
-				Parser: parser.Config{
+				Parser: ParserConfig{
 					UseJSONTagName: true,
 				},
-				Formatter: formatter.Config{
+				Formatter: FormatterConfig{
 					MaskValue:            "[CENSORED]",
 					DisplayPointerSymbol: true,
 					DisplayStructName:    true,
@@ -124,10 +121,10 @@ func TestYAMLMarshal(t *testing.T) {
 			General: General{
 				PrintConfigOnInit: true,
 			},
-			Parser: parser.Config{
+			Parser: ParserConfig{
 				UseJSONTagName: true,
 			},
-			Formatter: formatter.Config{
+			Formatter: FormatterConfig{
 				MaskValue:            "[CENSORED]",
 				DisplayPointerSymbol: true,
 				DisplayStructName:    true,

--- a/processor_test.go
+++ b/processor_test.go
@@ -687,10 +687,10 @@ func TestNewWithConfig(t *testing.T) {
 		General: General{
 			PrintConfigOnInit: true,
 		},
-		Parser: parser.Config{
+		Parser: ParserConfig{
 			UseJSONTagName: false,
 		},
-		Formatter: formatter.Config{
+		Formatter: FormatterConfig{
 			MaskValue:            "####",
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
@@ -808,10 +808,10 @@ func TestProcessor_PrintConfig(t *testing.T) {
 			General: General{
 				PrintConfigOnInit: true,
 			},
-			Parser: parser.Config{
+			Parser: ParserConfig{
 				UseJSONTagName: false,
 			},
-			Formatter: formatter.Config{
+			Formatter: FormatterConfig{
 				MaskValue:            DefaultMaskValue,
 				DisplayPointerSymbol: true,
 				DisplayStructName:    true,


### PR DESCRIPTION
# Pull request

### Link to the related ticket
NA

### Description of changes
Use parser and formatter config aliases in censor pkg instead of original config structs.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
