### PR TITLE
fix: [CN-42] print config in NewWithConfig constructor only when such option is enabled

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -47,7 +47,9 @@ func NewWithConfig(c Config) *Processor {
 		cfg:       c,
 	}
 
-	p.PrintConfig()
+	if c.General.PrintConfigOnInit {
+		p.PrintConfig()
+	}
 
 	return &p
 }


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-42

### Description of changes
Print config in NewWithConfig function call only if such an option is enabled in the config itself.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
