### PR TITLE
feat: [CN-45] print only non-default configuration

### DIFF
--- a/processor_test.go
+++ b/processor_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestProcessor2_Format(t *testing.T) {
+func TestProcessor_Format(t *testing.T) {
 	type Address struct {
 		Country string `censor:"display"`
 		City    string
@@ -35,8 +35,8 @@ func TestProcessor2_Format(t *testing.T) {
 
 	cfg := Config{
 		PrintConfigOnInit: true,
-		//MaskValue:         "Censored7",
-		ExcludePatterns: []string{"[0-9]"},
+		MaskValue:         "[CENSORED]",
+		ExcludePatterns:   []string{"[0-9]"},
 	}
 
 	p, err := NewWithOpts(WithConfig(&cfg))
@@ -45,13 +45,4 @@ func TestProcessor2_Format(t *testing.T) {
 	}
 
 	fmt.Println(p.Format(m))
-
-}
-
-func Bla(s string) error {
-	if s == "" {
-		return fmt.Errorf("empty string")
-	}
-
-	return nil
 }


### PR DESCRIPTION
1. Refactor PrintConfig function
2. Move Config text generation func to Config struct method

# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-45

### Description of changes
Print only non-default configuration.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
