### PR TITLE
feat: [CN-58] add structs fields caching to text encoder

### DIFF
--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -31,6 +31,10 @@ type baseEncoder struct {
 	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
 	// If no `json` tag is present, the name of the struct field is used.
 	UseJSONTagName bool
+
+	// structFieldsCache is used to cache struct fields, so we don't need to use reflection every time.
+	// Note: fields of anonymous structs are not cached due to the absence of a name.
+	structFieldsCache *fieldsCache
 }
 
 // Config describes censor Encoder configuration.

--- a/internal/encoder/json_encoder.go
+++ b/internal/encoder/json_encoder.go
@@ -16,12 +16,12 @@ import (
 func NewJSONEncoder(c Config) *JSONEncoder {
 	e := &JSONEncoder{
 		baseEncoder: baseEncoder{
-			CensorFieldTag:  DefaultCensorFieldTag,
-			ExcludePatterns: c.ExcludePatterns,
-			MaskValue:       strconv.Quote(c.MaskValue),
+			CensorFieldTag:    DefaultCensorFieldTag,
+			ExcludePatterns:   c.ExcludePatterns,
+			MaskValue:         strconv.Quote(c.MaskValue),
+			structFieldsCache: newFieldsCache(defaultMaxCacheSize),
 		},
-		enableEscaping:    c.EnableJSONEscaping,
-		structFieldsCache: newFieldsCache(defaultMaxCacheSize),
+		enableEscaping: c.EnableJSONEscaping,
 	}
 
 	if len(e.ExcludePatterns) != 0 {
@@ -36,9 +36,6 @@ type JSONEncoder struct {
 	baseEncoder
 
 	enableEscaping bool
-	// structFieldsCache is used to cache struct fields, so we don't need to use reflection every time.
-	// Note: fields of anonymous structs are not cached due to the absence of a name.
-	structFieldsCache *fieldsCache
 }
 
 // Field is a struct that contains information about a struct field.

--- a/internal/encoder/json_encoder_test.go
+++ b/internal/encoder/json_encoder_test.go
@@ -16,10 +16,10 @@ func TestJSONEncoder_NewJSONEncoder(t *testing.T) {
 	})
 	exp := &JSONEncoder{
 		baseEncoder: baseEncoder{
-			CensorFieldTag: DefaultCensorFieldTag,
-			MaskValue:      "\"[CENSORED]\"",
+			CensorFieldTag:    DefaultCensorFieldTag,
+			MaskValue:         "\"[CENSORED]\"",
+			structFieldsCache: newFieldsCache(defaultMaxCacheSize),
 		},
-		structFieldsCache: newFieldsCache(defaultMaxCacheSize),
 	}
 	require.EqualValues(t, exp, got)
 }

--- a/internal/encoder/text_encoder_test.go
+++ b/internal/encoder/text_encoder_test.go
@@ -14,8 +14,9 @@ func TestTextEncoder_NewTextEncoder(t *testing.T) {
 	got := NewTextEncoder(Config{UseJSONTagName: true})
 	exp := &TextEncoder{
 		baseEncoder: baseEncoder{
-			CensorFieldTag: DefaultCensorFieldTag,
-			UseJSONTagName: true,
+			CensorFieldTag:    DefaultCensorFieldTag,
+			UseJSONTagName:    true,
+			structFieldsCache: newFieldsCache(defaultMaxCacheSize),
 		},
 	}
 	require.EqualValues(t, exp, got)
@@ -102,7 +103,7 @@ func TestTextEncoder_Encode(t *testing.T) {
 			`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`,
 		},
 		MaskValue:      "[CENSORED]",
-		UseJSONTagName: true,
+		UseJSONTagName: false,
 	})
 	var b strings.Builder
 	defer b.Reset()
@@ -113,7 +114,7 @@ func TestTextEncoder_Encode(t *testing.T) {
 	// THEN.
 	exp := `encoder.payload{` +
 		`String: string, StringMasked: [CENSORED], StringWithRegexp: [CENSORED], ` +
-		`IntTag: 1, Byte: 97, Int8: 2, Int16: 3, Int32: 4, Int64: 5, Uint: 6, Uint8: 7, Uint16: 8, ` +
+		`Int: 1, Byte: 97, Int8: 2, Int16: 3, Int32: 4, Int64: 5, Uint: 6, Uint8: 7, Uint16: 8, ` +
 		`Uint32: 9, Uint64: 10, Rune: 121, Float32: 1.1, Float64: 2.2, Bool: true, ` +
 		`Interface: encoder.nested{String: string, Interface: interface}, ` +
 		`Struct: encoder.nested{String: string, Interface: interface}, ` +


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-58

### Description of changes
Add structures fields caching to text encoder. 
This will allow to parse the distinct structs only once and reduce the memory allocations.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
