### PR TITLE
fix: [61] adjust JSON encoder

### DIFF
--- a/config.go
+++ b/config.go
@@ -51,7 +51,6 @@ func DefaultConfig() Config {
 			DisplayMapType:       false,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
-			EnableJSONEscaping:   true,
 			ExcludePatterns:      nil,
 			MaskValue:            DefaultMaskValue,
 			UseJSONTagName:       false,

--- a/config_test.go
+++ b/config_test.go
@@ -20,7 +20,6 @@ func TestConfig_Default(t *testing.T) {
 			DisplayMapType:       false,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,
-			EnableJSONEscaping:   true,
 			ExcludePatterns:      nil,
 			MaskValue:            DefaultMaskValue,
 			UseJSONTagName:       false,
@@ -159,7 +158,6 @@ func TestConfig_ToString(t *testing.T) {
 			DisplayMapType:       true,
 			DisplayPointerSymbol: true,
 			DisplayStructName:    true,
-			EnableJSONEscaping:   false,
 			ExcludePatterns:      []string{`\d`, `^\w$`},
 			MaskValue:            "[CENSORED]",
 			UseJSONTagName:       true,
@@ -180,7 +178,6 @@ func TestConfig_ToString(t *testing.T) {
 		"    display-map-type: true\n" +
 		"    display-pointer-symbol: true\n" +
 		"    display-struct-name: true\n" +
-		"    enable-json-escaping: false\n" +
 		"    exclude-patterns:\n" +
 		"        - \\d\n" +
 		"        - ^\\w$\n" +

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=

--- a/handlers/json-test.json
+++ b/handlers/json-test.json
@@ -1,0 +1,7 @@
+{
+  "key": {
+    "Name": "Petro Perekotypole",
+    "Text": "so\"me text with [CENSORED] data",
+    "Email": "[CENSORED]"
+  }
+}

--- a/handlers/json-test.json
+++ b/handlers/json-test.json
@@ -1,7 +1,0 @@
-{
-  "key": {
-    "Name": "Petro Perekotypole",
-    "Text": "so\"me text with [CENSORED] data",
-    "Email": "[CENSORED]"
-  }
-}

--- a/handlers/slog/handler.go
+++ b/handlers/slog/handler.go
@@ -2,7 +2,6 @@ package sloghandler
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -32,7 +31,7 @@ func NewJSONHandler(opts ...Option) *slog.JSONHandler {
 		censorCfg.General.PrintConfigOnInit = false
 
 		// Error can be discarded here because the default configuration is always successfully parsed.
-		cfg.censor, _ = censor.NewWithOpts(censor.WithConfig(&censorCfg))
+		cfg.censor, _ = censor.NewWithOpts(censor.WithConfig(&censorCfg)) //nolint:errcheck
 	}
 
 	if cfg.out == nil {
@@ -50,7 +49,6 @@ func NewJSONHandler(opts ...Option) *slog.JSONHandler {
 		case slog.TimeKey, slog.LevelKey, slog.SourceKey:
 			return attr
 		default:
-			fmt.Println("attr.Key", string(json.RawMessage(cfg.censor.Format(attr.Value.Any()))))
 			return slog.Any(attr.Key, json.RawMessage(cfg.censor.Format(attr.Value.Any())))
 		}
 	}

--- a/handlers/slog/handler.go
+++ b/handlers/slog/handler.go
@@ -1,6 +1,8 @@
 package sloghandler
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -25,7 +27,12 @@ func NewJSONHandler(opts ...Option) *slog.JSONHandler {
 	}
 
 	if cfg.censor == nil {
-		cfg.censor = censor.New()
+		censorCfg := censor.DefaultConfig()
+		censorCfg.General.OutputFormat = censor.OutputFormatJSON
+		censorCfg.General.PrintConfigOnInit = false
+
+		// Error can be discarded here because the default configuration is always successfully parsed.
+		cfg.censor, _ = censor.NewWithOpts(censor.WithConfig(&censorCfg))
 	}
 
 	if cfg.out == nil {
@@ -43,7 +50,8 @@ func NewJSONHandler(opts ...Option) *slog.JSONHandler {
 		case slog.TimeKey, slog.LevelKey, slog.SourceKey:
 			return attr
 		default:
-			return slog.Any(attr.Key, cfg.censor.Format(attr.Value.Any()))
+			fmt.Println("attr.Key", string(json.RawMessage(cfg.censor.Format(attr.Value.Any()))))
+			return slog.Any(attr.Key, json.RawMessage(cfg.censor.Format(attr.Value.Any())))
 		}
 	}
 

--- a/handlers/slog/handler_test.go
+++ b/handlers/slog/handler_test.go
@@ -113,7 +113,7 @@ func TestNewHandler(t *testing.T) {
 					"level": "TEST",
 					"msg": "test",
     				"payload": {"City": "Kyiv", "Country": "Ukraine", "Street": "[CENSORED]", "Zip": "[CENSORED]"}
-}`
+				 }`
 
 		// WHEN
 		log.Info("test", slog.Any("payload", payload))

--- a/handlers/slog/handler_test.go
+++ b/handlers/slog/handler_test.go
@@ -18,7 +18,7 @@ type source struct {
 type logEntry struct {
 	Level   string  `json:"level"`
 	Msg     string  `json:"msg"`
-	Payload string  `json:"payload"`
+	Payload any     `json:"payload"`
 	Source  *source `json:"source,omitempty"`
 }
 
@@ -37,14 +37,6 @@ func TestNewHandler(t *testing.T) {
 		Zip:     12345,
 	}
 
-	t.Run("without output option", func(t *testing.T) {
-		// GIVEN
-		handler := NewJSONHandler()
-		log := slog.New(handler)
-		// WHEN
-		log.Info("test", slog.Any("payload", payload))
-	})
-
 	t.Run("with default handler options", func(t *testing.T) {
 		// GIVEN
 		var buf bytes.Buffer
@@ -53,7 +45,7 @@ func TestNewHandler(t *testing.T) {
 		want := `{
     				"level": "INFO",
     				"msg": "test",
-    				"payload": "{City: Kyiv, Country: Ukraine, Street: [CENSORED], Zip: [CENSORED]}"
+    				"payload": {"City": "Kyiv", "Country": "Ukraine", "Street": "[CENSORED]", "Zip": "[CENSORED]"}
 				 }`
 
 		// WHEN
@@ -73,9 +65,9 @@ func TestNewHandler(t *testing.T) {
 		want := `{
 					"level": "INFO",
 					"msg": "test",
-					"payload": "{City: Kyiv, Country: Ukraine, Street: [CENSORED], Zip: [CENSORED]}",
+    				"payload": {"City": "Kyiv", "Country": "Ukraine", "Street": "[CENSORED]", "Zip": "[CENSORED]"},
 					"source": {
-						"function": "github.com/vpakhuchyi/censor/handlers/slog.TestNewHandler.func3"
+						"function": "github.com/vpakhuchyi/censor/handlers/slog.TestNewHandler.func2"
 					}
 				 }`
 
@@ -120,8 +112,8 @@ func TestNewHandler(t *testing.T) {
 		want := `{
 					"level": "TEST",
 					"msg": "test",
-					"payload": "{City: Kyiv, Country: Ukraine, Street: [CENSORED], Zip: [CENSORED]}"
-				 }`
+    				"payload": {"City": "Kyiv", "Country": "Ukraine", "Street": "[CENSORED]", "Zip": "[CENSORED]"}
+}`
 
 		// WHEN
 		log.Info("test", slog.Any("payload", payload))

--- a/handlers/zap/doc.go
+++ b/handlers/zap/doc.go
@@ -1,5 +1,5 @@
 /*
-Package zaphandler provides a configurable logging handler for go.uber.org/zap library, allowing users
+Package zaphandler provides a configurable logging handler for the go.uber.org/zap library, allowing users
 to apply censoring to log entries and fields, overriding the original values before passing them to the core.
 
 Due to the diversity of the zap library usage, please pay attention to the way you use it with the censor handler.
@@ -37,48 +37,58 @@ Output:
 {"level":"info",...,"msg":"user","payload":"{Name: John Doe, Email: [CENSORED]}"}
 
 Describing the logger usage we can operate with a few keywords: "msg", "key" and "value".
-For example, in a call to l.Info("payload", zap.Any("addresses", []string{"address1", "address2"})):
+For example, in a call to `l.Info("payload", zap.Any("addresses", []string{"address1", "address2"}))`:
   - "payload" is a "msg"
   - "addresses" is a "key"
   - []string{"address1", "address2"} is a "value"
 
-By default, censor processes only "value" to minimize the overhead. The "msg" and "key" rarely contain sensitive data.
-However, there are predefined configuration options that can be passed to NewHandler() function to customize the
-censor handler behavior.
+By default, censor processes only "value" to minimize the overhead. The "msg" and "key" rarely contain sensitive data,
+because it's usually a static string or a key name. So, it's the user's responsibility to care about these fields.
+Enabling censor for "msg" and "key" would increase the overhead and may lead to performance issues.
 
 The following options are available:
-1. WithCensor(censor *censor.Processor) - sets the censor processor instance for the zap handler.
-If not provided, a default censor processor is used.
-2. WithMessagesFormat() - enables the censoring of a log "msg" values if such are present.
-3. WithKeysFormat() - enables the censoring of log "key" values.
+  - `WithCensor(censor *censor.Processor)` - sets the censor processor instance for the zap handler.
+    If not provided, a default censor processor is used.
 
 After the handler is initialized, it can be used as a regular zap logger. Because the censor handler is a wrapper around
 go.uber.org/zap library logic, it may not be compatible with all the possible ways of the logger usage.
 
-That's why it's recommended to use it with the following constructions:
+# Logger Usage Recommendations
 
-  - l.Info(msg string, fields ...zap.Field)
+While the zaphandler works seamlessly with the unsugared logger, its compatibility with the sugared logger is limited.
+Supported Unsugared Methods:
 
-  - l.With(fields ...zap.Field).Info(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Debug(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Panic(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Info(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Debug(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Warn(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Error(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Panic(msg string, fields ...zap.Field)
+	With(fields ...zap.Field).Fatal(msg string, fields ...zap.Field)
 
-    In both cases, Info could be replaced with Debug, Warn, Error, Panic, Fatal.
+Supported Sugared Methods:
 
-With sugared logger, the following constructions are supported:
+	Infow(msg string, keysAndValues ...interface{})
+	Debugw(msg string, keysAndValues ...interface{})
+	Warnw(msg string, keysAndValues ...interface{})
+	Errorw(msg string, keysAndValues ...interface{})
+	Panicw(msg string, keysAndValues ...interface{})
+	Fatalw(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Infow(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Debugw(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Warnw(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Errorw(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Panicw(msg string, keysAndValues ...interface{})
+	With(args ...interface{}).Fatalw(msg string, keysAndValues ...interface{})
 
-  - l.Info(args ...interface{})
-
-  - l.Infof(template string, args ...interface{})
-
-  - l.Infow(msg string, keysAndValues ...interface{})
-
-  - l.Infoln(args ...interface{})
-
-  - l.With(args ...interface{}).Info(args ...interface{})
-
-    In all cases, Info could be replaced with Debug, Warn, Error, Panic, Fatal.
-
-Methods ending in "f", "ln" and log.Print-style (l.Info) in a sugared logger can't use all the
-censor handler features. Due to the nature of the zap sugared logger, censor accepts formatted strings and has no
-possibility to use its parsing. However, a features like regexp matching are still available.
+Other methods that are not listed here are not supported due to the way data is handled by zap before passing it
+to the censor handler. Such methods concatenate arguments using fmt.Sprint-like functions and pass them to the censor
+handler as single formatted strings. As a result, the censor handler cannot process individual values, and sensitive
+data within these concatenated strings will not be censored.
 */
 package zaphandler

--- a/handlers/zap/handler.go
+++ b/handlers/zap/handler.go
@@ -25,7 +25,12 @@ func NewHandler(core zapcore.Core, opts ...Option) zapcore.Core {
 	}
 
 	if cc.censor == nil {
-		cc.censor = censor.New()
+		censorCfg := censor.DefaultConfig()
+		censorCfg.General.OutputFormat = censor.OutputFormatJSON
+		censorCfg.General.PrintConfigOnInit = false
+
+		// Error can be discarded here because the default configuration is always successfully parsed.
+		cc.censor, _ = censor.NewWithOpts(censor.WithConfig(&censorCfg)) //nolint:errcheck
 	}
 
 	return &cc
@@ -62,6 +67,7 @@ func (h handler) With(fields []zapcore.Field) zapcore.Core {
 		censor: h.censor,
 	}
 }
+
 func (h handler) censorField(f *zapcore.Field) {
 	if f.String != "" {
 		f.String = h.censor.String(f.String)

--- a/handlers/zap/handler_test.go
+++ b/handlers/zap/handler_test.go
@@ -1,6 +1,7 @@
 package zaphandler
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestNewHandler(t *testing.T) {
-	// Description of the data that is used in the tests.
+	const logFileName = "test_log"
 
 	c, err := censor.NewWithOpts(censor.WithConfig(&censor.Config{
 		Encoder: encoder.Config{
@@ -30,11 +31,7 @@ func TestNewHandler(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	const logFileName = "test_log"
-
-	msg := "some-msg"
-	key := "key"
-
+	msg, key := "some-msg", "key"
 	value := struct {
 		Name  string `censor:"display"`
 		Text  string `censor:"display"`
@@ -45,26 +42,7 @@ func TestNewHandler(t *testing.T) {
 		Email: "example@example.com",
 	}
 
-	// Unsugared logger.
-	t.Run("info example", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithCensor(c))
-		})
-
-		cfg := zap.NewProductionConfig()
-		l, err := cfg.Build(core)
-		require.NoError(t, err)
-
-		// WHEN.
-		//l.Info(msg, zap.Any(key, value))
-		//l.Info(msg, zap.String(value.Name, value.Text))
-		l.Info(msg, zap.Any(key, value))
-
-		// THEN.
-	})
-
-	// Unsugared logger.
+	// Un-sugared logger.
 	t.Run("info", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
@@ -239,153 +217,53 @@ func TestNewHandler(t *testing.T) {
 		require.Contains(t, string(got), want)
 	})
 
-	//// Sugared logger.
-	//t.Run("info", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// Note: the output of the Sugared logger is different from the output of the Unsugared logger.
-	//	// Censor handler receives a zap.Field not a provided value itself. That's why the output is different.
-	//	want := `"msg":"[CENSORED] msg{[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
-	//
-	//	// WHEN.
-	//	sl.Info(msg, key, value)
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//	fmt.Println(string(got))
-	//	require.Contains(t, string(got), want)
-	//})
-	//
-	//t.Run("infof with args", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// WHEN.
-	//	sl.Infof("key=%v, val=%v", key, value)
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//
-	//	want := `"msg":"key=[CENSORED] key, val={Petro Perekotypole some text with [CENSORED] data example@example.com}`
-	//
-	//	require.NoError(t, err)
-	//	require.Contains(t, string(got), want)
-	//})
-	//
-	//t.Run("infof with zap.Any()", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// WHEN.
-	//	sl.Infof("field=%v", zap.Any(key, value))
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//
-	//	want := `"msg":"field={[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
-	//
-	//	require.NoError(t, err)
-	//	require.Contains(t, string(got), want)
-	//})
-	//
-	//t.Run("infow with zap.Any()", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// WHEN.
-	//	sl.Infow(msg, zap.Any(key, value))
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//
-	//	want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
-	//
-	//	require.NoError(t, err)
-	//	require.Contains(t, string(got), want)
-	//})
-	//
-	//t.Run("infow with args", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// WHEN.
-	//	sl.Infow(msg, key, value)
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//
-	//	want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
-	//
-	//	require.NoError(t, err)
-	//	require.Contains(t, string(got), want)
-	//})
-	//
-	//t.Run("infoln", func(t *testing.T) {
-	//	// GIVEN.
-	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-	//		return NewHandler(core, WithCensor(c))
-	//	})
-	//	outputPath := path.Join(t.TempDir(), logFileName)
-	//	outputFile, err := os.Create(outputPath)
-	//	require.NoError(t, err)
-	//
-	//	l := newTestProductionZap(t, outputPath, core)
-	//	sl := l.Sugar()
-	//
-	//	// WHEN.
-	//	sl.Infoln(msg, key, value)
-	//
-	//	// THEN.
-	//	got := readLogs(t, outputFile)
-	//
-	//	// Note: only censor regexp pattern procesing is supported for Infoln method.
-	//	// That's happened because the Infoln method converts all arguments to a string on the early stage.
-	//	want := `"msg":"[CENSORED] msg [CENSORED] key {Petro Perekotypole some text with [CENSORED] data example@example.com}`
-	//
-	//	require.NoError(t, err)
-	//	require.Contains(t, string(got), want)
-	//})
+	// Sugared logger.
+	t.Run("info", func(t *testing.T) {
+		// GIVEN.
+		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return NewHandler(core, WithCensor(c))
+		})
+		outputPath := path.Join(t.TempDir(), logFileName)
+		outputFile, err := os.Create(outputPath)
+		require.NoError(t, err)
+
+		l := newTestProductionZap(t, outputPath, core)
+		sl := l.Sugar()
+
+		want := `"key":{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
+
+		// WHEN.
+		//sl.Infow(msg, key, value)
+		sl.With(key, value).Infow(msg, key, value)
+
+		// THEN.
+		got := readLogs(t, outputFile)
+		fmt.Println(string(got))
+		require.Contains(t, string(got), want)
+	})
+
+	t.Run("info with default censor", func(t *testing.T) {
+		// GIVEN.
+		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return NewHandler(core)
+		})
+		outputPath := path.Join(t.TempDir(), logFileName)
+		outputFile, err := os.Create(outputPath)
+		require.NoError(t, err)
+
+		l := newTestProductionZap(t, outputPath, core)
+
+		// #sensitive# is not replaced with the mask value because the default censor is used and it
+		// has no configured exclude patterns.
+		want := `"key":{"Name":"Petro Perekotypole","Text":"so\"me text with #sensitive# data","Email":"[CENSORED]"}`
+
+		// WHEN.
+		l.Info(msg, zap.Any(key, value))
+
+		// THEN.
+		got := readLogs(t, outputFile)
+		require.Contains(t, string(got), want)
+	})
 }
 
 // readLogs reads logs from the output file and returns them as a byte slice.

--- a/handlers/zap/handler_test.go
+++ b/handlers/zap/handler_test.go
@@ -1,7 +1,6 @@
 package zaphandler
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -25,13 +24,16 @@ func TestNewHandler(t *testing.T) {
 			DisplayMapType:       false,
 			ExcludePatterns:      []string{`#sensitive#`},
 		},
+		General: censor.General{
+			OutputFormat: censor.OutputFormatJSON,
+		},
 	}))
 	require.NoError(t, err)
 
 	const logFileName = "test_log"
 
-	msg := "#sensitive# msg"
-	key := "#sensitive# key"
+	msg := "some-msg"
+	key := "key"
 
 	value := struct {
 		Name  string `censor:"display"`
@@ -39,41 +41,55 @@ func TestNewHandler(t *testing.T) {
 		Email string
 	}{
 		Name:  "Petro Perekotypole",
-		Text:  "some text with #sensitive# data",
+		Text:  `so"me text with #sensitive# data`,
 		Email: "example@example.com",
 	}
+
+	// Unsugared logger.
+	t.Run("info example", func(t *testing.T) {
+		// GIVEN.
+		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return NewHandler(core, WithCensor(c))
+		})
+
+		cfg := zap.NewProductionConfig()
+		l, err := cfg.Build(core)
+		require.NoError(t, err)
+
+		// WHEN.
+		//l.Info(msg, zap.Any(key, value))
+		//l.Info(msg, zap.String(value.Name, value.Text))
+		l.Info(msg, zap.Any(key, value))
+
+		// THEN.
+	})
 
 	// Unsugared logger.
 	t.Run("info", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
-		fmt.Println("outputPath", outputPath)
 		outputFile, err := os.Create(outputPath)
-		fmt.Println("outputFile", outputFile.Name())
-
 		require.NoError(t, err)
 
 		l := newTestProductionZap(t, outputPath, core)
+
+		want := `"key":{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
 
 		// WHEN.
 		l.Info(msg, zap.Any(key, value))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("info with string args", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
@@ -81,45 +97,20 @@ func TestNewHandler(t *testing.T) {
 
 		l := newTestProductionZap(t, outputPath, core)
 
+		want := `"Petro Perekotypole":"so\"me text with [CENSORED] data"`
+
 		// WHEN.
-		l.Info(msg, zap.String(value.Name, value.Email))
+		l.Info(msg, zap.String(value.Name, value.Text))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","Petro Perekotypole":"example@example.com"`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("info with msg only", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-
-		// WHEN.
-		l.Info(msg)
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("error", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
@@ -127,15 +118,13 @@ func TestNewHandler(t *testing.T) {
 
 		l := newTestProductionZap(t, outputPath, core)
 
+		want := `"key":{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
+
 		// WHEN.
 		l.Error(msg, zap.Any(key, value))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
@@ -149,47 +138,42 @@ func TestNewHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		l := newTestDevelopmentZap(t, outputPath, core)
-		l = l.WithOptions()
+
+		want := `{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
 
 		// WHEN.
 		l.Debug(msg, zap.Any(key, value))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `#sensitive# msg	{"#sensitive# key": "{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"}`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("warn", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
 		require.NoError(t, err)
 
 		l := newTestProductionZap(t, outputPath, core)
+
+		want := `{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
 
 		// WHEN.
 		l.Warn(msg, zap.Any(key, value))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("panic", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
@@ -197,22 +181,20 @@ func TestNewHandler(t *testing.T) {
 
 		l := newTestProductionZap(t, outputPath, core)
 
+		want := `{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
+
 		// WHEN.
 		require.Panics(t, func() { l.Panic(msg, zap.Any(key, value)) })
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("fatal", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
@@ -226,250 +208,184 @@ func TestNewHandler(t *testing.T) {
 		// Our goal is just to be sure that in case of such a call a censor handler works correctly.
 		l = l.WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic))
 
+		want := `{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
+
 		// WHEN.
 		require.Panics(t, func() { l.Fatal(msg, zap.Any(key, value)) })
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
 	t.Run("with info", func(t *testing.T) {
 		// GIVEN.
 		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
+			return NewHandler(core, WithCensor(c))
 		})
 		outputPath := path.Join(t.TempDir(), logFileName)
 		outputFile, err := os.Create(outputPath)
 		require.NoError(t, err)
 
 		l := newTestProductionZap(t, outputPath, core)
+
+		want := `"key":{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"},"key":{"Name":"Petro Perekotypole","Text":"so\"me text with [CENSORED] data","Email":"[CENSORED]"}`
 
 		// WHEN.
 		l.With(zap.Any(key, value)).Info(msg, zap.Any(key, value))
 
 		// THEN.
 		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
 		require.Contains(t, string(got), want)
 	})
 
-	t.Run("info with default censor", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core)
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-
-		// WHEN.
-		l.Info(msg, zap.Any(key, value))
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"#sensitive# msg","#sensitive# key":"{Name: Petro Perekotypole, Text: some text with #sensitive# data, Email: [CENSORED]}"`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("debug with higher level settings", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		cfg := zap.Config{
-			Level:       zap.NewAtomicLevelAt(zap.PanicLevel),
-			Development: false,
-			Sampling: &zap.SamplingConfig{
-				Initial:    100,
-				Thereafter: 100,
-			},
-			Encoding:         "json",
-			EncoderConfig:    zap.NewProductionEncoderConfig(),
-			OutputPaths:      []string{outputPath},
-			ErrorOutputPaths: []string{outputPath},
-		}
-
-		l, err := cfg.Build(core)
-		require.NoError(t, err)
-
-		// WHEN.
-		l.Debug(msg)
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := ``
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	// Sugared logger.
-	t.Run("info", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Info(msg, zap.Any(key, value))
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		// Note: the output of the Sugared logger is different from the output of the Unsugared logger.
-		// Censor handler receives a zap.Field not a provided value itself. That's why the output is different.
-		want := `"msg":"[CENSORED] msg{[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("infof with args", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Infof("key=%v, val=%v", key, value)
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"key=[CENSORED] key, val={Petro Perekotypole some text with [CENSORED] data example@example.com}`
-
-		//  #sensetive# msg{#sensetive# key 23 0  {Petro Perekotypole some text with #sensetive# data example@example.com}}
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("infof with zap.Any()", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Infof("field=%v", zap.Any(key, value))
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"field={[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("infow with zap.Any()", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Infow(msg, zap.Any(key, value))
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("infow with args", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Infow(msg, key, value)
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
-
-	t.Run("infoln", func(t *testing.T) {
-		// GIVEN.
-		core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return NewHandler(core, WithMessagesFormat(), WithKeysFormat(), WithCensor(c))
-		})
-		outputPath := path.Join(t.TempDir(), logFileName)
-		outputFile, err := os.Create(outputPath)
-		require.NoError(t, err)
-
-		l := newTestProductionZap(t, outputPath, core)
-		sl := l.Sugar()
-
-		// WHEN.
-		sl.Infoln(msg, key, value)
-
-		// THEN.
-		got := readLogs(t, outputFile)
-
-		// Note: only censor regexp pattern procesing is supported for Infoln method.
-		// That's happened because the Infoln method converts all arguments to a string on the early stage.
-		want := `"msg":"[CENSORED] msg [CENSORED] key {Petro Perekotypole some text with [CENSORED] data example@example.com}`
-
-		require.NoError(t, err)
-		require.Contains(t, string(got), want)
-	})
+	//// Sugared logger.
+	//t.Run("info", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// Note: the output of the Sugared logger is different from the output of the Unsugared logger.
+	//	// Censor handler receives a zap.Field not a provided value itself. That's why the output is different.
+	//	want := `"msg":"[CENSORED] msg{[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
+	//
+	//	// WHEN.
+	//	sl.Info(msg, key, value)
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//	fmt.Println(string(got))
+	//	require.Contains(t, string(got), want)
+	//})
+	//
+	//t.Run("infof with args", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// WHEN.
+	//	sl.Infof("key=%v, val=%v", key, value)
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//
+	//	want := `"msg":"key=[CENSORED] key, val={Petro Perekotypole some text with [CENSORED] data example@example.com}`
+	//
+	//	require.NoError(t, err)
+	//	require.Contains(t, string(got), want)
+	//})
+	//
+	//t.Run("infof with zap.Any()", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// WHEN.
+	//	sl.Infof("field=%v", zap.Any(key, value))
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//
+	//	want := `"msg":"field={[CENSORED] key 23 0  {Petro Perekotypole some text with [CENSORED] data example@example.com}}`
+	//
+	//	require.NoError(t, err)
+	//	require.Contains(t, string(got), want)
+	//})
+	//
+	//t.Run("infow with zap.Any()", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// WHEN.
+	//	sl.Infow(msg, zap.Any(key, value))
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//
+	//	want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
+	//
+	//	require.NoError(t, err)
+	//	require.Contains(t, string(got), want)
+	//})
+	//
+	//t.Run("infow with args", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// WHEN.
+	//	sl.Infow(msg, key, value)
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//
+	//	want := `"msg":"[CENSORED] msg","[CENSORED] key":"{Name: Petro Perekotypole, Text: some text with [CENSORED] data, Email: [CENSORED]}`
+	//
+	//	require.NoError(t, err)
+	//	require.Contains(t, string(got), want)
+	//})
+	//
+	//t.Run("infoln", func(t *testing.T) {
+	//	// GIVEN.
+	//	core := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	//		return NewHandler(core, WithCensor(c))
+	//	})
+	//	outputPath := path.Join(t.TempDir(), logFileName)
+	//	outputFile, err := os.Create(outputPath)
+	//	require.NoError(t, err)
+	//
+	//	l := newTestProductionZap(t, outputPath, core)
+	//	sl := l.Sugar()
+	//
+	//	// WHEN.
+	//	sl.Infoln(msg, key, value)
+	//
+	//	// THEN.
+	//	got := readLogs(t, outputFile)
+	//
+	//	// Note: only censor regexp pattern procesing is supported for Infoln method.
+	//	// That's happened because the Infoln method converts all arguments to a string on the early stage.
+	//	want := `"msg":"[CENSORED] msg [CENSORED] key {Petro Perekotypole some text with [CENSORED] data example@example.com}`
+	//
+	//	require.NoError(t, err)
+	//	require.Contains(t, string(got), want)
+	//})
 }
 
 // readLogs reads logs from the output file and returns them as a byte slice.

--- a/handlers/zap/options.go
+++ b/handlers/zap/options.go
@@ -16,29 +16,3 @@ func WithCensor(censor *censor.Processor) Option {
 		h.censor = censor
 	}
 }
-
-// WithMessagesFormat enables the censoring of a log message if such is present.
-// It's useful when the log message is built using the following patterns:
-//
-//	log.With(keysAndValues).Info(msg)
-//	log.Infow(msg, keysAndValues)
-//
-// This option allows censoring of the msg value.
-func WithMessagesFormat() Option {
-	return func(h *handler) {
-		h.formatMessages = true
-	}
-}
-
-// WithKeysFormat enables the censoring of log keys.
-// Keys are recognized using the zap logic. Here are some examples:
-//
-//	log.Infow("msg", "key", "val")
-//	log.With("key", "val").Info("msg")
-//
-// For more details, see the zap documentation, please.
-func WithKeysFormat() Option {
-	return func(h *handler) {
-		h.formatKeys = true
-	}
-}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,32 +1,31 @@
-package encoder
+package cache
 
-import (
-	"container/list"
-)
+import "container/list"
 
-const defaultMaxCacheSize = 500
+// DefaultMaxCacheSize is the default maximum cache size.
+const DefaultMaxCacheSize = 500
 
-// newFieldsCache creates a new cache for struct fields.
-func newFieldsCache(size int) *fieldsCache {
-	return &fieldsCache{
+// New creates a new cache for type T.
+func New[T comparable](size int) *Cache[T] {
+	return &Cache[T]{
 		size:  size,
 		keys:  list.New(),
-		cache: make(map[string][]Field),
+		cache: make(map[string]T),
 	}
 }
 
-// fieldsCache is a cache for struct fields.
-type fieldsCache struct {
+// Cache is a cache for type T.
+type Cache[T comparable] struct {
 	size  int
 	keys  *list.List
-	cache map[string][]Field
+	cache map[string]T
 }
 
 // Set adds a new key-value pair to the cache.
 // If the cache size exceeds the defaultMaxCacheSize, the oldest key-value pair is removed.
 // If the key already exists in the cache, the function will return immediately.
 // If the key does not exist in the cache, the key-value pair is added.
-func (c fieldsCache) Set(key string, value []Field) {
+func (c Cache[T]) Set(key string, value T) {
 	if _, found := c.cache[key]; found {
 		return
 	}
@@ -43,7 +42,7 @@ func (c fieldsCache) Set(key string, value []Field) {
 
 // Get returns the value for the given key.
 // If the key does not exist in the cache, the second return value is false.
-func (c fieldsCache) Get(key string) ([]Field, bool) {
+func (c Cache[T]) Get(key string) (T, bool) {
 	value, found := c.cache[key]
 
 	return value, found

--- a/internal/cache/cache_slice.go
+++ b/internal/cache/cache_slice.go
@@ -1,0 +1,46 @@
+package cache
+
+import "container/list"
+
+// NewSlice creates a new cache for type []T.
+func NewSlice[T comparable](size int) *SliceCache[T] {
+	return &SliceCache[T]{
+		size:  size,
+		keys:  list.New(),
+		cache: make(map[string][]T),
+	}
+}
+
+// SliceCache is a cache for type []T.
+type SliceCache[T comparable] struct {
+	size  int
+	keys  *list.List
+	cache map[string][]T
+}
+
+// Set adds a new key-value pair to the cache.
+// If the cache size exceeds the defaultMaxCacheSize, the oldest key-value pair is removed.
+// If the key already exists in the cache, the function will return immediately.
+// If the key does not exist in the cache, the key-value pair is added.
+func (c SliceCache[T]) Set(key string, value []T) {
+	if _, found := c.cache[key]; found {
+		return
+	}
+
+	if c.keys.Len() >= c.size {
+		oldestKey := c.keys.Front().Value.(string) //nolint
+		delete(c.cache, oldestKey)
+		c.keys.Remove(c.keys.Front())
+	}
+
+	c.keys.PushBack(key)
+	c.cache[key] = value
+}
+
+// Get returns the value for the given key.
+// If the key does not exist in the cache, the second return value is false.
+func (c SliceCache[T]) Get(key string) ([]T, bool) {
+	value, found := c.cache[key]
+
+	return value, found
+}

--- a/internal/cache/cache_slice_test.go
+++ b/internal/cache/cache_slice_test.go
@@ -1,4 +1,4 @@
-package encoder
+package cache
 
 import (
 	"testing"
@@ -6,15 +6,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type Field struct {
+	Name     string
+	IsMasked bool
+}
+
 func TestFieldsCache_Get(t *testing.T) {
 	// GIVEN
 	key := "key"
 	fields := []Field{{Name: "name"}}
-	cache := newFieldsCache(10)
-	cache.Set(key, fields)
+	c := NewSlice[Field](10)
+	c.Set(key, fields)
 
 	// WHEN
-	got, found := cache.Get(key)
+	got, found := c.Get(key)
 
 	// THEN
 	require.True(t, found)
@@ -26,35 +31,35 @@ func TestFieldsCache_Set(t *testing.T) {
 		// GIVEN
 		key := "key"
 		fields := []Field{{Name: "name"}}
-		cache := newFieldsCache(10)
-		cache.Set(key, fields)
+		c := NewSlice[Field](10)
+		c.Set(key, fields)
 
 		// WHEN
-		cache.Set(key, []Field{{Name: "name2"}})
+		c.Set(key, []Field{{Name: "name2"}})
 
 		// THEN
-		got, found := cache.Get(key)
+		got, found := c.Get(key)
 		require.True(t, found)
 		require.Equal(t, fields, got)
-		require.Equal(t, 1, cache.keys.Len())
-		require.Len(t, cache.cache, 1)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		// GIVEN
 		key := "key"
 		fields := []Field{{Name: "name"}}
-		cache := newFieldsCache(10)
+		c := NewSlice[Field](10)
 
 		// WHEN
-		cache.Set(key, fields)
+		c.Set(key, fields)
 
 		// THEN
-		got, found := cache.Get(key)
+		got, found := c.Get(key)
 		require.True(t, found)
 		require.Equal(t, fields, got)
-		require.Equal(t, 1, cache.keys.Len())
-		require.Len(t, cache.cache, 1)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
 	})
 
 	t.Run("cache size exceeds the defaultMaxCacheSize", func(t *testing.T) {
@@ -63,20 +68,20 @@ func TestFieldsCache_Set(t *testing.T) {
 		key2 := "key2"
 		fields1 := []Field{{Name: "name1"}}
 		fields2 := []Field{{Name: "name2"}}
-		cache := newFieldsCache(1)
+		c := NewSlice[Field](1)
 
 		// WHEN
-		cache.Set(key1, fields1)
-		cache.Set(key2, fields2)
+		c.Set(key1, fields1)
+		c.Set(key2, fields2)
 
 		// THEN
-		got1, found1 := cache.Get(key1)
-		got2, found2 := cache.Get(key2)
+		got1, found1 := c.Get(key1)
+		got2, found2 := c.Get(key2)
 		require.Empty(t, got1)
 		require.Equal(t, fields2, got2)
 		require.False(t, found1)
 		require.True(t, found2)
-		require.Equal(t, 1, cache.keys.Len())
-		require.Len(t, cache.cache, 1)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
 	})
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,77 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_Get(t *testing.T) {
+	// GIVEN
+	key, value := "key", "value"
+	c := New[string](10)
+	c.Set(key, value)
+
+	// WHEN
+	got, found := c.Get(key)
+
+	// THEN
+	require.True(t, found)
+	require.Equal(t, value, got)
+}
+
+func TestCache_Set(t *testing.T) {
+	t.Run("cache already exists", func(t *testing.T) {
+		// GIVEN
+		key, value := "key", "value"
+		c := New[string](10)
+		c.Set(key, value)
+
+		// WHEN
+		c.Set(key, "value2")
+
+		// THEN
+		got, found := c.Get(key)
+		require.True(t, found)
+		require.Equal(t, value, got)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		// GIVEN
+		key, value := "key", "value"
+		c := New[string](10)
+
+		// WHEN
+		c.Set(key, value)
+
+		// THEN
+		got, found := c.Get(key)
+		require.True(t, found)
+		require.Equal(t, value, got)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
+	})
+
+	t.Run("cache size exceeds the defaultMaxCacheSize", func(t *testing.T) {
+		// GIVEN
+		key1, value1 := "key1", "value1"
+		key2, value2 := "key2", "value2"
+		c := New[string](1)
+
+		// WHEN
+		c.Set(key1, value1)
+		c.Set(key2, value2)
+
+		// THEN
+		got1, found1 := c.Get(key1)
+		got2, found2 := c.Get(key2)
+		require.Empty(t, got1)
+		require.Equal(t, value2, got2)
+		require.False(t, found1)
+		require.True(t, found2)
+		require.Equal(t, 1, c.keys.Len())
+		require.Len(t, c.cache, 1)
+	})
+}

--- a/internal/cache/doc.go
+++ b/internal/cache/doc.go
@@ -1,0 +1,9 @@
+/*
+Package cache provides a generic, size-limited cache for storing key-value pairs efficiently.
+
+The `cache` package offers a simple and performant caching mechanism using Go's generics. It allows
+developers to store and retrieve values of any comparable type with automatic eviction of the oldest
+entries when the cache reaches its maximum capacity. This ensures optimal memory usage and prevents
+the cache from growing indefinitely.
+*/
+package cache

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -57,6 +57,7 @@ type baseEncoder struct {
 	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
 	// If no `json` tag is present, the name of the struct field is used.
 	UseJSONTagName bool
+
 	// structFieldsCache is used to cache struct fields, so we don't need to use reflection every time.
 	// Note: fields of anonymous structs are not cached due to the absence of a name.
 	structFieldsCache *cache.SliceCache[Field]

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/vpakhuchyi/censor/internal/builderpool"
 	"github.com/vpakhuchyi/censor/internal/cache"
 )
 
@@ -17,6 +18,29 @@ type Encoder interface {
 	Interface(b *strings.Builder, rv reflect.Value)
 	String(b *strings.Builder, s string)
 	Encode(b *strings.Builder, f reflect.Value)
+}
+
+// Config describes censor Encoder configuration.
+type Config struct {
+	// DisplayMapType is used to display map type in the output.
+	// The default value is false.
+	DisplayMapType bool `yaml:"display-map-type"`
+	// DisplayPointerSymbol is used to display '&' (pointer symbol) in the output.
+	// The default value is false.
+	DisplayPointerSymbol bool `yaml:"display-pointer-symbol"`
+	// DisplayStructName is used to display struct name in the output.
+	// A struct name includes the last part of the package path.
+	// The default value is false.
+	DisplayStructName bool `yaml:"display-struct-name"`
+	// ExcludePatterns contains regexp patterns that are used for the selection
+	// of strings that must be masked.
+	ExcludePatterns []string `yaml:"exclude-patterns"`
+	// MaskValue is used to mask struct fields with sensitive data.
+	// The default value is stored in DefaultMaskValue constant.
+	MaskValue string `yaml:"mask-value"`
+	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
+	// If no `json` tag is present, the name of the struct field is used.
+	UseJSONTagName bool `yaml:"use-json-tag-name"`
 }
 
 type baseEncoder struct {
@@ -42,25 +66,32 @@ type baseEncoder struct {
 	regexpCache *cache.Cache[string]
 }
 
-// Config describes censor Encoder configuration.
-type Config struct {
-	// DisplayMapType is used to display map type in the output.
-	// The default value is false.
-	DisplayMapType bool `yaml:"display-map-type"`
-	// DisplayPointerSymbol is used to display '&' (pointer symbol) in the output.
-	// The default value is false.
-	DisplayPointerSymbol bool `yaml:"display-pointer-symbol"`
-	// DisplayStructName is used to display struct name in the output.
-	// A struct name includes the last part of the package path.
-	// The default value is false.
-	DisplayStructName bool `yaml:"display-struct-name"`
-	// ExcludePatterns contains regexp patterns that are used for the selection
-	// of strings that must be masked.
-	ExcludePatterns []string `yaml:"exclude-patterns"`
-	// MaskValue is used to mask struct fields with sensitive data.
-	// The default value is stored in DefaultMaskValue constant.
-	MaskValue string `yaml:"mask-value"`
-	// UseJSONTagName sets whether to use the `json` tag to get the name of the struct field.
-	// If no `json` tag is present, the name of the struct field is used.
-	UseJSONTagName bool `yaml:"use-json-tag-name"`
+// String processes the input string by masking any substrings that match the configured exclusion patterns.
+// It replaces matched segments with a predefined mask value to censor sensitive information.
+func (e *baseEncoder) String(s string) string {
+	res := s
+	if len(e.ExcludePatterns) != 0 && e.ExcludePatternsCompiled != nil {
+		cached, ok := e.regexpCache.Get(s)
+		if ok {
+			return cached
+		}
+
+		matches := e.ExcludePatternsCompiled.FindAllStringIndex(s, -1)
+		if len(matches) > 0 {
+			bb := builderpool.Get()
+			lastIndex := 0
+			for _, m := range matches {
+				start, end := m[0], m[1]
+				bb.WriteString(s[lastIndex:start] + e.MaskValue)
+				lastIndex = end
+			}
+
+			bb.WriteString(s[lastIndex:])
+			res = bb.String()
+		}
+	}
+
+	e.regexpCache.Set(s, res)
+
+	return res
 }

--- a/internal/encoder/text_encoder.go
+++ b/internal/encoder/text_encoder.go
@@ -35,6 +35,7 @@ func NewTextEncoder(c Config) *TextEncoder {
 			MaskValue:         c.MaskValue,
 			UseJSONTagName:    c.UseJSONTagName,
 			structFieldsCache: cache.NewSlice[Field](cache.DefaultMaxCacheSize),
+			regexpCache:       cache.New[string](cache.DefaultMaxCacheSize),
 		},
 		DisplayMapType:       c.DisplayMapType,
 		DisplayPointerSymbol: c.DisplayPointerSymbol,
@@ -262,21 +263,5 @@ func (e *TextEncoder) Ptr(b *strings.Builder, rv reflect.Value) {
 // String formats a value as a string.
 // If the string matches one of the ExcludePatterns, it will be masked with the MaskValue.
 func (e *TextEncoder) String(b *strings.Builder, s string) {
-	if len(e.ExcludePatterns) != 0 && e.ExcludePatternsCompiled != nil {
-		matches := e.ExcludePatternsCompiled.FindAllStringIndex(s, -1)
-		if len(matches) > 0 {
-			lastIndex := 0
-			for _, match := range matches {
-				start, end := match[0], match[1]
-				b.WriteString(s[lastIndex:start] + e.MaskValue)
-				lastIndex = end
-			}
-
-			b.WriteString(s[lastIndex:])
-
-			return
-		}
-	}
-
-	b.WriteString(s)
+	b.WriteString(e.baseEncoder.String(s))
 }

--- a/internal/encoder/text_encoder.go
+++ b/internal/encoder/text_encoder.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/vpakhuchyi/censor/internal/cache"
 )
 
 // TextEncoder is a struct that contains options for parsing.
@@ -32,7 +34,7 @@ func NewTextEncoder(c Config) *TextEncoder {
 			ExcludePatterns:   c.ExcludePatterns,
 			MaskValue:         c.MaskValue,
 			UseJSONTagName:    c.UseJSONTagName,
-			structFieldsCache: newFieldsCache(defaultMaxCacheSize),
+			structFieldsCache: cache.NewSlice[Field](cache.DefaultMaxCacheSize),
 		},
 		DisplayMapType:       c.DisplayMapType,
 		DisplayPointerSymbol: c.DisplayPointerSymbol,

--- a/internal/encoder/text_encoder_test.go
+++ b/internal/encoder/text_encoder_test.go
@@ -19,6 +19,7 @@ func TestTextEncoder_NewTextEncoder(t *testing.T) {
 			CensorFieldTag:    DefaultCensorFieldTag,
 			UseJSONTagName:    true,
 			structFieldsCache: cache.NewSlice[Field](cache.DefaultMaxCacheSize),
+			regexpCache:       cache.New[string](cache.DefaultMaxCacheSize),
 		},
 	}
 	require.EqualValues(t, exp, got)

--- a/internal/encoder/text_encoder_test.go
+++ b/internal/encoder/text_encoder_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/vpakhuchyi/censor/internal/cache"
 )
 
 func TestTextEncoder_NewTextEncoder(t *testing.T) {
@@ -16,7 +18,7 @@ func TestTextEncoder_NewTextEncoder(t *testing.T) {
 		baseEncoder: baseEncoder{
 			CensorFieldTag:    DefaultCensorFieldTag,
 			UseJSONTagName:    true,
-			structFieldsCache: newFieldsCache(defaultMaxCacheSize),
+			structFieldsCache: cache.NewSlice[Field](cache.DefaultMaxCacheSize),
 		},
 	}
 	require.EqualValues(t, exp, got)

--- a/processor.go
+++ b/processor.go
@@ -98,6 +98,10 @@ func (p *Processor) Format(val any) string {
 	return p.encode(val)
 }
 
+// Any takes any value and returns a string representation of it masking struct fields by default.
+// To override this behaviour, use the `censor:"display"` tag.
+// Formatting is done recursively for all nested structs/slices/arrays/pointers/maps/interfaces.
+// If a value implements [encoding.TextMarshaler], the result of MarshalText is written.
 func (p *Processor) Any(val any) string {
 	if val == nil || reflect.TypeOf(val) == nil {
 		return "nil"
@@ -106,6 +110,8 @@ func (p *Processor) Any(val any) string {
 	return p.encode(val)
 }
 
+// String takes a string and validates it against the regular expressions specified in the configuration.
+// If the match is found, it is replaced with the mask value.
 func (p *Processor) String(s string) string {
 	b := builderpool.Get()
 

--- a/processor.go
+++ b/processor.go
@@ -98,6 +98,25 @@ func (p *Processor) Format(val any) string {
 	return p.encode(val)
 }
 
+func (p *Processor) Any(val any) string {
+	if val == nil || reflect.TypeOf(val) == nil {
+		return "nil"
+	}
+
+	return p.encode(val)
+}
+
+func (p *Processor) String(s string) string {
+	b := builderpool.Get()
+
+	p.encoder.String(b, s)
+	res := b.String()
+
+	builderpool.Put(b)
+
+	return res
+}
+
 // Clone returns a new instance of Processor with the same configuration as the original one.
 func (p *Processor) Clone() (*Processor, error) {
 	return NewWithOpts(WithConfig(&p.cfg))

--- a/processor_test.go
+++ b/processor_test.go
@@ -132,7 +132,6 @@ func TestProcessor_PrintConfig(t *testing.T) {
 				DisplayMapType:       true,
 				DisplayPointerSymbol: true,
 				DisplayStructName:    true,
-				EnableJSONEscaping:   false,
 				ExcludePatterns:      []string{`\d`, `.+@.+`},
 				MaskValue:            DefaultMaskValue,
 				UseJSONTagName:       true,

--- a/testdata/cfg.yml
+++ b/testdata/cfg.yml
@@ -5,7 +5,6 @@ encoder:
     display-map-type: true
     display-pointer-symbol: true
     display-struct-name: true
-    enable-json-escaping: false
     exclude-patterns:
         - \d
         - ^\w$

--- a/testdata/default.yml
+++ b/testdata/default.yml
@@ -5,7 +5,6 @@ encoder:
     display-map-type: false
     display-pointer-symbol: false
     display-struct-name: false
-    enable-json-escaping: true
     exclude-patterns: []
     mask-value: '[CENSORED]'
     use-json-tag-name: false

--- a/testdata/valid_config_console_output.txt
+++ b/testdata/valid_config_console_output.txt
@@ -8,7 +8,6 @@ encoder:
     display-map-type: true
     display-pointer-symbol: true
     display-struct-name: true
-    enable-json-escaping: false
     exclude-patterns:
         - \d
         - .+@.+


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-61

### Description of changes
1. Change JSON encoder implementation to have a valid JSON data as the output
2. Update zap/slog JSON handlers to censor only provided values (exclude: msg, keys etc)
3. Add new cache for slice types

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [ ] The documentation has been updated (if applicable).
