### PR TITLE
feat: [CN-66] add config file validation, update the default values

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -178,14 +178,14 @@ Table below shows the names of the configuration options:
 | Go name              | YML name               | Default value | Description                                                                                                                                                  |
 |----------------------|------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OutputFormat         | output-format          | text          | The output format that will be used for the formatted values (text or json).                                                                                 |
-| PrintConfigOnInit    | print-config-on-init   | true          | If true, the configuration will be printed when any of available constructors is used.                                                                       |
+| PrintConfigOnInit    | print-config-on-init   | false         | If true, the configuration will be printed when any of available constructors is used.                                                                       |
 | UseJSONTagName       | use-json-tag-name      | false         | If true, the JSON tag name will be used instead of the Go struct field name.                                                                                 |
 | MaskValue            | mask-value             | [CENSORED]    | The value that will be used to mask the sensitive information.                                                                                               |
 | DisplayStructName    | display-struct-name    | false         | If true, the struct name will be displayed in the output.                                                                                                    |
 | DisplayMapType       | display-map-type       | false         | If true, the map type will be displayed in the output.                                                                                                       |
 | DisplayPointerSymbol | display-pointer-symbol | false         | If true, '&' (the pointer symbol) will be displayed in the output.                                                                                           |
 | EnableJSONEscaping   | enable-json-escaping   | true          | If true, the JSON escaping will be enabled.                                                                                                                  |
-| ExcludePatterns      | exclude-patterns       | []            | A list of regular expressions that will be compared against all the string values. <br/>If a value matches any of the patterns, that section will be masked. |
+| ExcludePatterns      | exclude-patterns       | []            | A list of regular expressions that will be compared against all the string values. <br/>If a value matches any of the patterns, that section will be masked. Up to 50 patterns are allowed. |
 
 
 ### Using the `censor.Config` struct

--- a/handlers/zap/handler_test.go
+++ b/handlers/zap/handler_test.go
@@ -11,14 +11,13 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/vpakhuchyi/censor"
-	"github.com/vpakhuchyi/censor/internal/encoder"
 )
 
 func TestNewHandler(t *testing.T) {
 	const logFileName = "test_log"
 
 	c, err := censor.NewWithOpts(censor.WithConfig(&censor.Config{
-		Encoder: encoder.Config{
+		Encoder: censor.EncoderConfig{
 			MaskValue:            censor.DefaultMaskValue,
 			DisplayPointerSymbol: false,
 			DisplayStructName:    false,

--- a/testdata/default.yml
+++ b/testdata/default.yml
@@ -1,10 +1,10 @@
 general:
-    output-format: json 
-    print-config-on-init: true
+  output-format: json
+  print-config-on-init: false
 encoder:
-    display-map-type: false
-    display-pointer-symbol: false
-    display-struct-name: false
-    exclude-patterns: []
-    mask-value: '[CENSORED]'
-    use-json-tag-name: false
+  display-map-type: false
+  display-pointer-symbol: false
+  display-struct-name: false
+  exclude-patterns: []
+  mask-value: "[CENSORED]"
+  use-json-tag-name: false


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-66

### Description of changes
- replace the public encoder config alias with a dedicated struct and converter
- change PrintConfigOnInit default to false and refresh docs/fixtures/tests
- add Config.Validate, enforce it in constructors, and cover with tests

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
