### PR TITLE
fix: [CN-67] prevent zerolog handler from overriding global marshaller

### DIFF
--- a/handlers/slog/doc.go
+++ b/handlers/slog/doc.go
@@ -1,61 +1,62 @@
-/*
-Package sloghandler provides a configurable logging handler for the Slog library, allowing users
-to customize various aspects of log handling, including output destination, log level, attribute
-replacement, and source information addition.
-
-Example struct with censor tags:
-
-	type User struct {
-		Name  string `censor:"display"`
-		Email string
-	}
-
-	u := User{
-		Name:  "John Doe",
-		Email: "example@gmail.com",
-	}
-
-Usage with default options:
-
-	handler := NewJSONHandler()
-	log := slog.New(handler)
-	log.Info("user", slog.Any("payload", u))
-
-Output:
-{"time":"2023-12-28T20:15:45.893115+01:00","level":"INFO","msg":"user","payload":{"Name": "John Doe","Email": "[CENSORED]"}}
-
-Usage with custom options:
-
-	censorInst := censor.New()
-	opts := []Option{
-		WithOut(os.Stdout),
-		WithCensor(censorInst),
-		WithAddSource(),
-		WithReplaceAttr(func(groups []string, a slog.Attr) slog.Attr {
-			if a.Key == "msg" {
-				return slog.Any("msg", "replaced msg")
-			}
-
-			return a
-		}),
-	}
-
-	handler := NewJSONHandler(opts...)
-	log := slog.New(handler)
-	log.Info("user", slog.Any("payload", u))
-
-Output:
-
-		{
-	    	"time": "2023-12-28T20:22:44.35868+01:00",
-	    	"level": "INFO",
-	    	"source": {
-	        	"function": "github.com/vpakhuchyi/censor/handlers/slog.TestFunc",
-	        	"file": "/Users/volodymyr/Files/source/censor/handlers/slog/handler_test.go",
-	        	"line": "156"
-	    	},
-	    	"msg": "replaced msg",
-	    	"payload": {"Name": "John Doe","Email": "[CENSORED]"}
-		}
-*/
 package sloghandler
+
+/*
+Package sloghandler integrates github.com/vpakhuchyi/censor with log/slog by providing drop-in handlers that mask
+sensitive values before they are rendered. The handler wraps slog’s JSON/Text handlers, forwarding every record after
+running it through a censor. This is useful when you want to keep using slog’s native APIs while ensuring that only the
+fields explicitly tagged for display remain readable.
+
+Typical workflow:
+
+	import (
+		"log/slog"
+		"os"
+
+		"github.com/vpakhuchyi/censor"
+		sloghandler "github.com/vpakhuchyi/censor/handlers/slog"
+	)
+
+	func main() {
+		type User struct {
+			Name       string `censor:"display"`
+			Department string `censor:"display"`
+			Email      string
+			Token      string
+		}
+
+		payload := User{
+			Name:       "Hryhorii Skovoroda",
+			Department: "Philosophy",
+			Email:      "h.skovoroda@example.com",
+			Token:      "S3cr3t!",
+		}
+
+		handler := sloghandler.NewJSONHandler()
+		logger := slog.New(handler)
+
+		logger.Info("profile loaded", slog.Any("payload", payload))
+
+		// Output:
+		// {"time":"2024-06-02T15:04:05Z","level":"INFO","msg":"profile loaded","payload":{"Name":"Hryhorii Skovoroda","Department":"Philosophy","Email":"[CENSORED]","Token":"[CENSORED]"}}
+	}
+
+Important considerations:
+
+  - Only attribute values are masked. The log message itself (the string passed to logger.Info) and attribute keys remain
+    untouched, so avoid placing sensitive data there.
+  - The handler defaults to JSON output writing to os.Stdout. Use WithOut to point it at another io.Writer, or
+    WithAddSource to include caller information.
+  - Providing WithCensor lets you reuse an existing *censor.Processor, keeping configuration consistent across services.
+  - WithReplaceAttr is applied after censoring. If you replace the value with a string, ensure you do not reintroduce
+    sensitive information.
+
+Supported options:
+
+  - WithCensor(*censor.Processor) — reuse a prepared processor instead of the default.
+  - WithOut(io.Writer) — change the target writer.
+  - WithAddSource() — include source metadata (file/line/function) in each record.
+  - WithReplaceAttr(func([]string, slog.Attr) slog.Attr) — post-process attributes (called after censoring).
+
+By composing these options, you can keep using slog as usual while guaranteeing that sensitive payload data is
+automatically redacted.
+*/

--- a/handlers/zap/doc.go
+++ b/handlers/zap/doc.go
@@ -1,94 +1,94 @@
+package zaphandler
+
 /*
-Package zaphandler provides a configurable logging handler for the go.uber.org/zap library, allowing users
-to apply censoring to log entries and fields, overriding the original values before passing them to the core.
+Package zaphandler integrates github.com/vpakhuchyi/censor with go.uber.org/zap by wrapping an existing zapcore.Core
+and sanitizing fields before they reach the underlying core. It is designed for structured logging flows where values
+are passed as zap.Field arguments; message strings remain unchanged unless you handle them separately.
 
-Due to the diversity of the zap library usage, please pay attention to the way you use it with the censor handler.
-
-Example of censor handler initialization:
+Typical workflow:
 
 	import (
-		censorlog "github.com/vpakhuchyi/censor/handlers/zap"
 		"go.uber.org/zap"
 		"go.uber.org/zap/zapcore"
+
+		"github.com/vpakhuchyi/censor"
+		zaphandler "github.com/vpakhuchyi/censor/handlers/zap"
 	)
 
-	type User struct {
-		Name  string `censor:"display"`
-		Email string
+	func main() {
+		type User struct {
+			Name       string `censor:"display"`
+			Department string `censor:"display"`
+			Email      string
+			Token      string
+		}
+
+		processor := censor.New()
+
+		logger, err := zap.NewProduction(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return zaphandler.NewHandler(core, zaphandler.WithCensor(processor))
+		}))
+		if err != nil {
+			panic(err)
+		}
+
+		payload := User{
+			Name:       "Hryhorii Skovoroda",
+			Department: "Philosophy",
+			Email:      "hryhorii.skovoroda@example.com",
+			Token:      "S3cr3t!",
+		}
+
+		logger.Info("user",
+			zap.String("name", payload.Name),
+			zap.Any("payload", payload),
+		)
+
+		// Output:
+		// {"level":"info","msg":"user","name":"Hryhorii Skovoroda","payload":{"Name":"Hryhorii Skovoroda","Department":"Philosophy","Email":"[CENSORED]","Token":"[CENSORED]"}}
 	}
 
-	u := User{
-		Name:  "John Doe",
-		Email: "example@gmail.com",
-	}
+Important considerations:
 
-	o := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		return censorlog.NewHandler(core)
-	})
+  - The handler sanitizes zap.Field values (strings, reflective payloads, etc.) before delegating to the wrapped core.
+    Message strings and key names are untouched, so review them separately if they may contain sensitive data.
+  - WithCensor allows you to reuse a shared *censor.Processor; if omitted, NewHandler falls back to a default processor.
+  - Because the handler wraps the supplied core, it inherits that core’s encoder, sampling, and level configuration.
+    Apply those settings before wrapping.
+  - Zap’s formatting helpers that collapse arguments into a single string (for example, Infof or Infoln) are not
+    supported—the handler cannot recover individual values from those strings.
 
-	l, err := zap.NewProduction(o)
-	if err != nil {
-		// handle error
-	}
+Supported zap methods:
 
-	l.Info("user", zap.Any("payload", u))
+  Unsugared:
+    - Info(msg string, fields ...zap.Field)
+    - Debug(msg string, fields ...zap.Field)
+    - Warn(msg string, fields ...zap.Field)
+    - Error(msg string, fields ...zap.Field)
+    - Panic(msg string, fields ...zap.Field)
+    - Fatal(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Info(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Debug(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Warn(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Error(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Panic(msg string, fields ...zap.Field)
+    - With(fields ...zap.Field).Fatal(msg string, fields ...zap.Field)
 
-Output:
-{"level":"info",...,"msg":"user","payload":{"Name": "John Doe","Email": "[CENSORED]"}}
+  Sugared:
+    - Infow(msg string, keysAndValues ...interface{})
+    - Debugw(msg string, keysAndValues ...interface{})
+    - Warnw(msg string, keysAndValues ...interface{})
+    - Errorw(msg string, keysAndValues ...interface{})
+    - Panicw(msg string, keysAndValues ...interface{})
+    - Fatalw(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Infow(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Debugw(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Warnw(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Errorw(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Panicw(msg string, keysAndValues ...interface{})
+    - With(args ...interface{}).Fatalw(msg string, keysAndValues ...interface{})
 
-Describing the logger usage we can operate with a few keywords: "msg", "key" and "value".
-For example, in a call to `l.Info("payload", zap.Any("addresses", []string{"address1", "address2"}))`:
-  - "payload" is a "msg"
-  - "addresses" is a "key"
-  - []string{"address1", "address2"} is a "value"
-
-By default, censor processes only "value" to minimize the overhead. The "msg" and "key" rarely contain sensitive data,
-because it's usually a static string or a key name. So, it's the user's responsibility to care about these fields.
-Enabling censor for "msg" and "key" would increase the overhead and may lead to performance issues.
-
-The following options are available:
-  - `WithCensor(censor *censor.Processor)` - sets the censor processor instance for the zap handler.
-    If not provided, a default censor processor is used.
-
-After the handler is initialized, it can be used as a regular zap logger. Because the censor handler is a wrapper around
-go.uber.org/zap library logic, it may not be compatible with all the possible ways of the logger usage.
-
-# Logger Usage Recommendations
-
-While the zaphandler works seamlessly with the unsugared logger, its compatibility with the sugared logger is limited.
-Supported Unsugared Methods:
-
-	Info(msg string, fields ...zap.Field)
-	Debug(msg string, fields ...zap.Field)
-	Warn(msg string, fields ...zap.Field)
-	Error(msg string, fields ...zap.Field)
-	Panic(msg string, fields ...zap.Field)
-	Fatal(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Info(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Debug(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Warn(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Error(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Panic(msg string, fields ...zap.Field)
-	With(fields ...zap.Field).Fatal(msg string, fields ...zap.Field)
-
-Supported Sugared Methods:
-
-	Infow(msg string, keysAndValues ...interface{})
-	Debugw(msg string, keysAndValues ...interface{})
-	Warnw(msg string, keysAndValues ...interface{})
-	Errorw(msg string, keysAndValues ...interface{})
-	Panicw(msg string, keysAndValues ...interface{})
-	Fatalw(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Infow(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Debugw(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Warnw(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Errorw(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Panicw(msg string, keysAndValues ...interface{})
-	With(args ...interface{}).Fatalw(msg string, keysAndValues ...interface{})
-
-Other methods that are not listed here are not supported due to the way data is handled by zap before passing it
-to the censor handler. Such methods concatenate arguments using fmt.Sprint-like functions and pass them to the censor
-handler as single formatted strings. As a result, the censor handler cannot process individual values, and sensitive
-data within these concatenated strings will not be censored.
+  Unsupported formatting helpers (non-exhaustive):
+    - Infof / Debugf / Warnf / Errorf / Panicf / Fatalf
+    - Infoln / Debugln / Warnln / Errorln / Panicln / Fatalln
 */
-package zaphandler

--- a/handlers/zerolog/doc.go
+++ b/handlers/zerolog/doc.go
@@ -1,0 +1,65 @@
+package zerologhandler
+
+/*
+Package zerologhandler integrates github.com/vpakhuchyi/censor with github.com/rs/zerolog by providing helpers
+that build and install a censor-aware marshal function. Zerolog exposes a single global hook,
+zerolog.InterfaceMarshalFunc, for customizing how values passed through Any/Interface are encoded. To keep the side
+effect explicit and reversible, this package lets you derive the marshal function separately from installing it.
+
+Typical workflow:
+
+	import (
+		"os"
+
+		"github.com/rs/zerolog"
+		"github.com/vpakhuchyi/censor"
+		zerologhandler "github.com/vpakhuchyi/censor/handlers/zerolog"
+	)
+
+	func main() {
+		type User struct {
+			Name       string `censor:"display"`
+			Department string `censor:"display"`
+			Email      string
+			Token      string
+		}
+
+		processor := censor.New()
+
+		// Build a marshal function that uses the custom processor (other options like WithZerolog are available).
+		marshal := zerologhandler.GetMarshalFunc(
+			zerologhandler.WithCensor(processor),
+		)
+
+		// Install the marshal function globally and defer restoration of the previous zerolog.InterfaceMarshalFunc.
+		restore := zerologhandler.InstallMarshalFunc(marshal)
+		defer restore()
+
+		// Construct or reuse a zerolog.Logger. The helper New(...) is available for convenience.
+		logger := zerologhandler.New().With().Str("component", "example").Logger()
+
+		payload := User{
+			Name:       "Hryhorii Skovoroda",
+			Department: "Philosophy",
+			Email:      "hryhorii.skovoroda@example.com",
+			Token:      "S3cr3t!",
+		}
+
+		logger.Info().
+			Any("payload", payload).
+			Msg("user profile loaded")
+
+		// Output:
+		// {"level":"info","component":"example","payload":{"Name":"Hryhorii Skovoroda","Department":"Philosophy","Email":"[CENSORED]","Token":"[CENSORED]"},"message":"user profile loaded"}
+	}
+
+Important considerations:
+
+  - Installing the marshal function affects every zerolog logger in the process until you call the restore callback.
+    Always restore the previous value when the override is no longer needed (for example, at the end of main or in
+    test cleanup).
+  - Options such as WithCensor and WithZerolog can be supplied to New and GetMarshalFunc so that loggers and marshal
+    functions share the same configuration.
+  - Types other than Any/Interface are still serialized by zerolog itself; they will not pass through Censor unless
+    zerolog exposes dedicated hooks for them in the future.
+*/

--- a/handlers/zerolog/handler.go
+++ b/handlers/zerolog/handler.go
@@ -30,6 +30,7 @@ func New(opts ...Option) *zerolog.Logger {
 // GetMarshalFunc returns a MarshalFunc that applies Censor before delegating to zerolog.
 func GetMarshalFunc(opts ...Option) MarshalFunc {
 	cfg := resolveOptions(opts...)
+
 	return func(v any) ([]byte, error) {
 		return cfg.censor.Any(v), nil
 	}

--- a/handlers/zerolog/handler.go
+++ b/handlers/zerolog/handler.go
@@ -2,6 +2,7 @@ package zerologhandler
 
 import (
 	"os"
+	"sync"
 
 	"github.com/rs/zerolog"
 
@@ -15,32 +16,59 @@ import (
 // Note: Currently, the Zerolog handler supports sanitizing data only for types `any`/`interface{}`.
 // All other types and primitives will be logged as-is. This limitation exists because Zerolog
 // provides an interface for modifying input data only for the `any`/`interface{}` type.
+var marshalMu sync.Mutex
+
+// MarshalFunc represents a function capable of marshaling values before zerolog encodes them.
+type MarshalFunc func(any) ([]byte, error)
+
+// New returns a zerolog.Logger configured with the supplied options.
+// Note: New does not install the marshal func; call InstallMarshalFunc to wire it globally.
 func New(opts ...Option) *zerolog.Logger {
-	h := new(handler)
-
-	for _, o := range opts {
-		o(h)
-	}
-
-	if h.censor == nil {
-		h.censor = censor.New()
-	}
-
-	if h.log == nil {
-		log := zerolog.New(os.Stdout)
-		h.log = &log
-	}
-
-	zerolog.InterfaceMarshalFunc = h.anyMarshal
-
-	return h.log
+	return resolveOptions(opts...).logger
 }
 
-type handler struct {
-	censor *censor.Processor
-	log    *zerolog.Logger
+// GetMarshalFunc returns a MarshalFunc that applies Censor before delegating to zerolog.
+func GetMarshalFunc(opts ...Option) MarshalFunc {
+	cfg := resolveOptions(opts...)
+	return func(v any) ([]byte, error) {
+		return cfg.censor.Any(v), nil
+	}
 }
 
-func (h *handler) anyMarshal(v any) ([]byte, error) {
-	return h.censor.Any(v), nil
+// InstallMarshalFunc sets fn as zerolog.InterfaceMarshalFunc and returns a restore function.
+func InstallMarshalFunc(fn MarshalFunc) func() {
+	if fn == nil {
+		return func() {}
+	}
+
+	marshalMu.Lock()
+	previous := zerolog.InterfaceMarshalFunc
+	zerolog.InterfaceMarshalFunc = func(v interface{}) ([]byte, error) {
+		return fn(v)
+	}
+	marshalMu.Unlock()
+
+	return func() {
+		marshalMu.Lock()
+		zerolog.InterfaceMarshalFunc = previous
+		marshalMu.Unlock()
+	}
+}
+
+func resolveOptions(opts ...Option) options {
+	cfg := options{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.censor == nil {
+		cfg.censor = censor.New()
+	}
+
+	if cfg.logger == nil {
+		l := zerolog.New(os.Stdout)
+		cfg.logger = &l
+	}
+
+	return cfg
 }

--- a/handlers/zerolog/options.go
+++ b/handlers/zerolog/options.go
@@ -5,23 +5,24 @@ import (
 	"github.com/vpakhuchyi/censor"
 )
 
-// Option represents a function that can be used to configure a Handler.
-// These options can be applied during the initialization of the Handler to modify
-// its configuration.
-type Option func(h *handler)
+type options struct {
+	censor *censor.Processor
+	logger *zerolog.Logger
+}
 
-// WithCensor sets the Censor processor instance for the Handler. If not provided,
-// a default Censor processor will be used.
-func WithCensor(censor *censor.Processor) Option {
-	return func(h *handler) {
-		h.censor = censor
+// Option configures the zerolog handler via a shared options struct.
+type Option func(cfg *options)
+
+// WithCensor stores the provided Censor processor on the options struct.
+func WithCensor(processor *censor.Processor) Option {
+	return func(cfg *options) {
+		cfg.censor = processor
 	}
 }
 
-// WithZerolog sets the Zerolog logger instance for the Handler. If not provided,
-// a default Zerolog logger will be used.
-func WithZerolog(log *zerolog.Logger) Option {
-	return func(h *handler) {
-		h.log = log
+// WithZerolog stores the provided zerolog logger on the options struct.
+func WithZerolog(logger *zerolog.Logger) Option {
+	return func(cfg *options) {
+		cfg.logger = logger
 	}
 }

--- a/handlers/zerolog/options_test.go
+++ b/handlers/zerolog/options_test.go
@@ -13,14 +13,14 @@ func TestWithCensor(t *testing.T) {
 	t.Run("should apply option with provided censor instance", func(t *testing.T) {
 		// GIVEN
 		censorInstance := censor.New()
-		h := handler{}
+		cfg := options{}
 
 		// WHEN
 		got := WithCensor(censorInstance)
-		got(&h)
+		got(&cfg)
 
 		// THEN
-		require.Equal(t, handler{censor: censorInstance}, h)
+		require.Equal(t, options{censor: censorInstance}, cfg)
 	})
 }
 
@@ -28,13 +28,13 @@ func TestWithZerolog(t *testing.T) {
 	t.Run("should apply option with provided zerolog logger instance", func(t *testing.T) {
 		// GIVEN
 		log := zerolog.New(os.Stdout)
-		h := handler{}
+		cfg := options{}
 
 		// WHEN
 		got := WithZerolog(&log)
-		got(&h)
+		got(&cfg)
 
 		// THEN
-		require.Equal(t, handler{log: &log}, h)
+		require.Equal(t, options{logger: &log}, cfg)
 	})
 }


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-67

### Description of changes
- add GetMarshalFunc/InstallMarshalFunc so censor integration is explicitly opt-in
- refactor handler options/tests and introduce doc.go coverage with struct payload examples
- align slog, zerolog and zap documentation

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
