### PR TITLE
fix: [CN-68] update TEXT and JSON encoders to correctly handle `nil` input

### DIFF
--- a/internal/encoder/json_encoder.go
+++ b/internal/encoder/json_encoder.go
@@ -40,6 +40,12 @@ type JSONEncoder struct {
 
 //nolint:exhaustive,gocyclo
 func (e *JSONEncoder) Encode(b *bytes.Buffer, f reflect.Value) {
+	if !f.IsValid() {
+		b.WriteString("null")
+
+		return
+	}
+
 	switch k := f.Kind(); k {
 	case reflect.Struct:
 		if f.CanInterface() {

--- a/internal/encoder/text_encoder.go
+++ b/internal/encoder/text_encoder.go
@@ -50,6 +50,12 @@ func NewTextEncoder(c Config) *TextEncoder {
 
 //nolint:exhaustive,gocyclo
 func (e *TextEncoder) Encode(b *bytes.Buffer, f reflect.Value) {
+	if !f.IsValid() {
+		b.WriteString("nil")
+
+		return
+	}
+
 	switch k := f.Kind(); k {
 	case reflect.Struct:
 		// If a field implements encoding.TextMarshaler interface, then it should be marshaled to string.

--- a/processor.go
+++ b/processor.go
@@ -123,7 +123,6 @@ func Any(val any) []byte {
 // Any returns a byte slice representation of the given value with sensitive data masked.
 // It behaves the same as the global Any function — recursively processing and masking values.
 func (p *Processor) Any(val any) []byte {
-
 	b := builderpool.Get()
 	defer builderpool.Put(b)
 

--- a/processor.go
+++ b/processor.go
@@ -123,9 +123,6 @@ func Any(val any) []byte {
 // Any returns a byte slice representation of the given value with sensitive data masked.
 // It behaves the same as the global Any function — recursively processing and masking values.
 func (p *Processor) Any(val any) []byte {
-	if val == nil || reflect.TypeOf(val) == nil {
-		return []byte("nil")
-	}
 
 	b := builderpool.Get()
 	defer builderpool.Put(b)

--- a/processor_test.go
+++ b/processor_test.go
@@ -287,6 +287,36 @@ func TestProcessor_Format(t *testing.T) {
 		got := Any(v)
 
 		// THEN.
+		require.Equal(t, "null", string(got))
+	})
+
+	t.Run("processor method nil value", func(t *testing.T) {
+		// GIVEN.
+		processor := New()
+
+		// WHEN.
+		got := processor.Any(nil)
+
+		// THEN.
+		require.Equal(t, "null", string(got))
+	})
+
+	t.Run("nil type with text encoder", func(t *testing.T) {
+		// GIVEN.
+		processor, err := NewWithOpts(WithConfig(&Config{
+			General: General{
+				OutputFormat: OutputFormatText,
+			},
+			Encoder: EncoderConfig{
+				MaskValue: DefaultMaskValue,
+			},
+		}))
+		require.NoError(t, err)
+
+		// WHEN.
+		got := processor.Any(nil)
+
+		// THEN.
 		require.Equal(t, "nil", string(got))
 	})
 }


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-68

### Description of changes
Update TEXT and JSON encoders to correctly handle `nil` input.

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
