### PR TITLE
fix: [CN-70] require JSON processors in log handlers

### DIFF
--- a/handlers/slog/doc.go
+++ b/handlers/slog/doc.go
@@ -27,7 +27,7 @@ Typical workflow:
 		payload := User{
 			Name:       "Hryhorii Skovoroda",
 			Department: "Philosophy",
-			Email:      "h.skovoroda@example.com",
+			Email:      "hryhorii.skovoroda@example.com",
 			Token:      "S3cr3t!",
 		}
 
@@ -47,6 +47,8 @@ Important considerations:
   - The handler defaults to JSON output writing to os.Stdout. Use WithOut to point it at another io.Writer, or
     WithAddSource to include caller information.
   - Providing WithCensor lets you reuse an existing *censor.Processor, keeping configuration consistent across services.
+  - The JSON handler requires a processor configured with OutputFormatJSON; supplying a text encoder will panic to avoid
+    producing invalid slog JSON.
   - WithReplaceAttr is applied after censoring. If you replace the value with a string, ensure you do not reintroduce
     sensitive information.
 

--- a/handlers/slog/handler.go
+++ b/handlers/slog/handler.go
@@ -29,6 +29,10 @@ func NewJSONHandler(opts ...Option) *slog.JSONHandler {
 		cfg.censor = censor.New()
 	}
 
+	if cfg.censor.OutputFormat() != censor.OutputFormatJSON {
+		panic("sloghandler: censor processor must use json output format")
+	}
+
 	if cfg.out == nil {
 		cfg.out = os.Stdout
 	}

--- a/handlers/slog/handler_test.go
+++ b/handlers/slog/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vpakhuchyi/censor"
 )
 
 type source struct {
@@ -122,6 +123,24 @@ func TestNewHandler(t *testing.T) {
 		require.NoError(t, out.Flush())
 		got := buf.String()
 		require.JSONEq(t, want, prepareLogEntry(t, got))
+	})
+
+	t.Run("text censor panics", func(t *testing.T) {
+		textCfg := censor.Config{
+			General: censor.General{
+				OutputFormat: censor.OutputFormatText,
+			},
+			Encoder: censor.EncoderConfig{
+				MaskValue: censor.DefaultMaskValue,
+			},
+		}
+
+		textProcessor, err := censor.NewWithOpts(censor.WithConfig(&textCfg))
+		require.NoError(t, err)
+
+		require.PanicsWithValue(t, "sloghandler: censor processor must use json output format", func() {
+			NewJSONHandler(WithCensor(textProcessor))
+		})
 	})
 }
 

--- a/handlers/zap/doc.go
+++ b/handlers/zap/doc.go
@@ -53,6 +53,8 @@ Important considerations:
   - The handler sanitizes zap.Field values (strings, reflective payloads, etc.) before delegating to the wrapped core.
     Message strings and key names are untouched, so review them separately if they may contain sensitive data.
   - WithCensor allows you to reuse a shared *censor.Processor; if omitted, NewHandler falls back to a default processor.
+  - The handler requires a processor configured with OutputFormatJSON; providing a text encoder panics to avoid emitting
+    invalid JSON.
   - Because the handler wraps the supplied core, it inherits that core’s encoder, sampling, and level configuration.
     Apply those settings before wrapping.
   - Zap’s formatting helpers that collapse arguments into a single string (for example, Infof or Infoln) are not

--- a/handlers/zap/handler.go
+++ b/handlers/zap/handler.go
@@ -26,6 +26,10 @@ func NewHandler(core zapcore.Core, opts ...Option) zapcore.Core {
 		cc.censor = censor.New()
 	}
 
+	if cc.censor.OutputFormat() != censor.OutputFormatJSON {
+		panic("zaphandler: censor processor must use json output format")
+	}
+
 	return &cc
 }
 

--- a/handlers/zap/handler_test.go
+++ b/handlers/zap/handler_test.go
@@ -263,6 +263,24 @@ func TestNewHandler(t *testing.T) {
 		got := readLogs(t, outputFile)
 		require.Contains(t, string(got), want)
 	})
+
+	t.Run("text censor panics", func(t *testing.T) {
+		textCfg := censor.Config{
+			General: censor.General{
+				OutputFormat: censor.OutputFormatText,
+			},
+			Encoder: censor.EncoderConfig{
+				MaskValue: censor.DefaultMaskValue,
+			},
+		}
+
+		textProcessor, err := censor.NewWithOpts(censor.WithConfig(&textCfg))
+		require.NoError(t, err)
+
+		require.PanicsWithValue(t, "zaphandler: censor processor must use json output format", func() {
+			NewHandler(zapcore.NewNopCore(), WithCensor(textProcessor))
+		})
+	})
 }
 
 // readLogs reads logs from the output file and returns them as a byte slice.

--- a/handlers/zerolog/doc.go
+++ b/handlers/zerolog/doc.go
@@ -60,6 +60,8 @@ Important considerations:
     test cleanup).
   - Options such as WithCensor and WithZerolog can be supplied to New and GetMarshalFunc so that loggers and marshal
     functions share the same configuration.
+  - The marshal helper requires a processor configured with OutputFormatJSON; text-mode processors will panic to
+    prevent zerolog from emitting invalid JSON.
   - Types other than Any/Interface are still serialized by zerolog itself; they will not pass through Censor unless
     zerolog exposes dedicated hooks for them in the future.
 */

--- a/handlers/zerolog/handler.go
+++ b/handlers/zerolog/handler.go
@@ -44,7 +44,7 @@ func InstallMarshalFunc(fn MarshalFunc) func() {
 
 	marshalMu.Lock()
 	previous := zerolog.InterfaceMarshalFunc
-	zerolog.InterfaceMarshalFunc = func(v interface{}) ([]byte, error) {
+	zerolog.InterfaceMarshalFunc = func(v any) ([]byte, error) {
 		return fn(v)
 	}
 	marshalMu.Unlock()
@@ -64,6 +64,10 @@ func resolveOptions(opts ...Option) options {
 
 	if cfg.censor == nil {
 		cfg.censor = censor.New()
+	}
+
+	if cfg.censor.OutputFormat() != censor.OutputFormatJSON {
+		panic("zerologhandler: censor processor must use json output format")
 	}
 
 	if cfg.logger == nil {

--- a/handlers/zerolog/handler_test.go
+++ b/handlers/zerolog/handler_test.go
@@ -119,11 +119,29 @@ func TestNewHandler(t *testing.T) {
 		// THEN
 		require.NoError(t, out.Flush())
 		want := `{
-					"level":"info",
-					"payload":{"City": "Kyiv","Country": "Ukraine","Street": "[CENSORED]","Zip": "[CENSORED]"},
-					"message":"test"
-				}`
+				"level":"info",
+				"payload":{"City": "Kyiv","Country": "Ukraine","Street": "[CENSORED]","Zip": "[CENSORED]"},
+				"message":"test"
+			}`
 		require.JSONEq(t, want, prepareLogEntry(t, buf.String()))
+	})
+
+	t.Run("with text censor panics", func(t *testing.T) {
+		textCfg := censor.Config{
+			General: censor.General{
+				OutputFormat: censor.OutputFormatText,
+			},
+			Encoder: censor.EncoderConfig{
+				MaskValue: censor.DefaultMaskValue,
+			},
+		}
+
+		textProcessor, err := censor.NewWithOpts(censor.WithConfig(&textCfg))
+		require.NoError(t, err)
+
+		require.PanicsWithValue(t, "zerologhandler: censor processor must use json output format", func() {
+			GetMarshalFunc(WithCensor(textProcessor))
+		})
 	})
 
 	t.Run("install marshal func restores previous function", func(t *testing.T) {

--- a/processor.go
+++ b/processor.go
@@ -89,7 +89,7 @@ func newProcessor(cfg Config) *Processor {
 		cfg: cfg,
 	}
 
-	if cfg.General.OutputFormat == "json" {
+	if cfg.General.OutputFormat == OutputFormatJSON {
 		p.encoder = encoder.NewJSONEncoder(cfg.Encoder.toEncoderConfig())
 	} else {
 		p.encoder = encoder.NewTextEncoder(cfg.Encoder.toEncoderConfig())
@@ -152,6 +152,15 @@ func (p *Processor) String(s string) []byte {
 	p.encoder.String(b, s)
 
 	return b.Bytes()
+}
+
+// OutputFormat returns the configured output format (OutputFormatJSON or OutputFormatText).
+func (p *Processor) OutputFormat() string {
+	if p == nil {
+		panic("censor: processor is nil")
+	}
+
+	return p.cfg.General.OutputFormat
 }
 
 // Clone returns a new instance of Processor with the same configuration as the original one.

--- a/processor_test.go
+++ b/processor_test.go
@@ -321,6 +321,36 @@ func TestProcessor_Format(t *testing.T) {
 	})
 }
 
+func TestProcessor_OutputFormat(t *testing.T) {
+	t.Run("json output", func(t *testing.T) {
+		p := New()
+		require.Equal(t, OutputFormatJSON, p.OutputFormat())
+	})
+
+	t.Run("text output", func(t *testing.T) {
+		cfg := Config{
+			General: General{
+				OutputFormat: OutputFormatText,
+			},
+			Encoder: EncoderConfig{
+				MaskValue: DefaultMaskValue,
+			},
+		}
+
+		p, err := NewWithOpts(WithConfig(&cfg))
+		require.NoError(t, err)
+		require.Equal(t, OutputFormatText, p.OutputFormat())
+	})
+
+	t.Run("nil processor", func(t *testing.T) {
+		var p *Processor
+
+		require.PanicsWithValue(t, "censor: processor is nil", func() {
+			p.OutputFormat()
+		})
+	})
+}
+
 func TestProcessor_GetGlobalInstance(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
 		// GIVEN.


### PR DESCRIPTION
# Pull request

### Link to the related ticket
https://censor.atlassian.net/browse/CN-70

### Description of changes
- add Processor.OutputFormat so integrations can inspect the active encoder
- guard zerolog, zap, and slog handlers against text-mode processors
- document the JSON requirement and cover panic paths with regression tests

### Checklist
Please ensure that your pull request complies with the following requirements:

- [x] The changes have been tested locally (if applicable).
- [x] The documentation has been updated (if applicable).
